### PR TITLE
refactor(locales): migrate LLM prompts from system to structured Open AI format

### DIFF
--- a/locales/locale.ar.yml
+++ b/locales/locale.ar.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Arabic.
+openai:
+  prompt: <task>Write a concise summary of the information presented.</task>\n<instructions>\n- Focus on key points.\n- Maintain the original structure and highlight main ideas under each section.\n- Write the summary in Arabic.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.cn.yml
+++ b/locales/locale.cn.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Chinese.
+openai:
+  prompt: <task>请对所提供的信息进行简明扼要的总结。</task>\n<instructions>\n- 重点突出关键点。\n- 保持原文结构，并在每个部分中突出主要观点。\n- 用中文撰写总结。\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.de.yml
+++ b/locales/locale.de.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in German.
+openai:
+  prompt: <task>Verfassen Sie eine kurze Zusammenfassung der präsentierten Informationen.</task>\n<instructions>\n- Konzentrieren Sie sich auf die wichtigsten Punkte.\n- Behalten Sie die ursprüngliche Struktur bei und heben Sie die Hauptideen unter jedem Abschnitt hervor.\n- Verfassen Sie die Zusammenfassung auf Deutsch.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.en.yml
+++ b/locales/locale.en.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in English.
+openai:
+  prompt: <task>Write a concise summary of the information presented.</task>\n<instructions>\n- Focus on key points.\n- Maintain the original structure and highlight main ideas under each section.\n- Write the summary in English.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.es.yml
+++ b/locales/locale.es.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Spanish.
+openai:
+  prompt: <task>Escribe un resumen conciso de la información presentada.</task>\n<instructions>\n- Enfócate en los puntos clave.\n- Mantén la estructura original y resalta las ideas principales de cada sección.\n- Escribe el resumen en español.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.fr.yml
+++ b/locales/locale.fr.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in French.
+openai:
+  prompt: <task>Rédigez un résumé concis des informations présentées.</task>\n<instructions>\n- Concentrez-vous sur les points clés.\n- Conservez la structure originale et mettez en évidence les idées principales de chaque section.\n- Rédigez le résumé en français.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.hi.yml
+++ b/locales/locale.hi.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Hindi.
+openai:
+  prompt: <task>दी गई जानकारी की छोटी समरी लिखें।</task>\n<instructions>\n- खास बातों पर ध्यान दें।\n- ओरिजिनल स्ट्रक्चर बनाए रखें और हर सेक्शन के तहत मुख्य आइडिया को हाईलाइट करें।\n- समरी हिंदी में लिखें।\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.it.yml
+++ b/locales/locale.it.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Italian.
+openai:
+  prompt: <task>Scrivi un riassunto conciso delle informazioni presentate.</task>\n<istruzioni>\n- Concentrati sui punti chiave.\n- Mantieni la struttura originale ed evidenzia le idee principali in ogni sezione.\n- Scrivi il riassunto in italiano.\n</istruzioni>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.ja.yml
+++ b/locales/locale.ja.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Japanese.
+openai:
+  prompt: <task>提示された情報の簡潔な要約を記述してください。</task>\n<instructions>\n- 重要なポイントに焦点を当ててください。\n- 元の構造を維持し、各セクションの主要なアイデアを強調してください。\n- 要約を日本語で記述してください。\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.ko.yml
+++ b/locales/locale.ko.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Korean.
+openai:
+  prompt: <task>제시된 정보를 간결하게 요약하세요.</task>\n<instructions>\n- 핵심 사항에 집중하세요.\n- 원래의 구조를 유지하고 각 섹션의 주요 아이디어를 강조하세요.\n- 요약은 한국어로 작성하세요.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.pt.yml
+++ b/locales/locale.pt.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Portuguese.
+openai:
+  prompt: <task>Escreva um resumo conciso da informação apresentada.</task>\n<instructions>\n- Concentre-se nos pontos principais. \n- Mantenha a estrutura original e destaque as ideias principais em cada secção. \n- Escreva o resumo em português. \n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.ru.yml
+++ b/locales/locale.ru.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Russian.
+openai:
+  prompt: <task>Напишите краткое резюме представленной информации.</task>\n<instructions>\n- Сосредоточьтесь на ключевых моментах.\n- Сохраняйте исходную структуру и выделяйте основные идеи в каждом разделе.\n- Напишите резюме на русском языке.\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/locales/locale.zh.yml
+++ b/locales/locale.zh.yml
@@ -17,5 +17,5 @@ telegram:
   response:
     title: 📖 **[%{title}](%{url})**
 
-llm:
-  system: I want you to act as a video summarizer. Write a concise summary of the information presented. Focus on key points and omitting timestamps. Maintain the original structure and highlight main ideas under each section. Write the summary in Chinese.
+openai:
+  prompt: <task>请对所提供的信息进行简明扼要的总结。</task>\n<instructions>\n- 重点突出关键点。\n- 保持原文结构，并在每个部分中突出主要观点。\n- 用中文撰写总结。\n</instructions>\n<data id="text">\n%{text}\n</data>

--- a/src/transform/summarization.py
+++ b/src/transform/summarization.py
@@ -65,7 +65,7 @@ class OpenAISummarizer:
             "Summarizing text",
             extra={"locale": locale, "text_length": len(text), "model": self.settings.openai_model},
         )
-        system_prompt = translate("llm.system", locale=locale)
+        prompt = translate("openai.prompt", locale=locale, text=text)
 
         last_error: Exception | None = None
         for attempt in range(self.settings.openai_max_retries):
@@ -74,8 +74,7 @@ class OpenAISummarizer:
                 response = self.client.chat.completions.create(
                     model=self.settings.openai_model,
                     messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": text},
+                        {"role": "user", "content": prompt},
                     ],
                     timeout=self.settings.openai_timeout_seconds,
                 )

--- a/tests/transform/test_summarization.py
+++ b/tests/transform/test_summarization.py
@@ -45,7 +45,7 @@ def test_summarizer_summarize_text_success() -> None:
 
         # Mock the translate function to return a fixed system prompt
         with patch("src.transform.summarization.translate") as mock_translate:
-            mock_translate.return_value = "You are a helpful assistant."
+            mock_translate.return_value = "Input text to summarize"
 
             summarizer = OpenAISummarizer(mock_settings)
             result = summarizer.summarize_text("Input text to summarize", "en")
@@ -54,7 +54,6 @@ def test_summarizer_summarize_text_success() -> None:
             mock_client_instance.chat.completions.create.assert_called_once_with(
                 model="gpt-3.5-turbo",
                 messages=[
-                    {"role": "system", "content": "You are a helpful assistant."},
                     {"role": "user", "content": "Input text to summarize"},
                 ],
                 timeout=300,


### PR DESCRIPTION
- Replace `llm.system` key with `openai.prompt` across all locale files
- Adopt XML-structured prompt format with `<task>`, `<instructions>`, and `<data>` tags
- Update `OpenAISummarizer` to use single user message with structured prompt

**BREAKING CHANGE**: The locale key `llm.system` is no longer supported. Update any custom locale files to use `openai.prompt` with the new XML-structured format that includes `%{text}` placeholder.