### PR TITLE
build(docker): update image registry and improve Dockerfile security

### DIFF
--- a/.devops/Telegram-build.sh
+++ b/.devops/Telegram-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-image_name="go-briefly-telegram"
+image_name="ghcr.io/olegshulyakov/go-briefly-bot"
 
 docker build -t "$image_name" --file .devops/Telegram.Dockerfile .

--- a/.devops/Telegram-run.sh
+++ b/.devops/Telegram-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-image_name="go-briefly-telegram"
+image_name="ghcr.io/olegshulyakov/go-briefly-bot"
 container_name="go-briefly-telegram"
 
 docker build -t "$image_name" --file .devops/Telegram.Dockerfile .

--- a/.devops/Telegram.Dockerfile
+++ b/.devops/Telegram.Dockerfile
@@ -2,15 +2,29 @@ FROM python:3.12-alpine
 
 WORKDIR /app
 
+# Install ffmpeg runtime (will be copied to final stage)
 RUN apk add --no-cache ffmpeg
 
+# Copy only pyproject.toml first for better layer caching
 COPY pyproject.toml ./
+
+# Install dependencies
 RUN python -m pip install --no-cache-dir .
 
+# Copy application code
 COPY src /app/src
 COPY locales /app/locales
 
+# Create data directory and set volume
 RUN mkdir -p /app/data
 VOLUME ["/app/data"]
+
+# Run as non-root user for security
+ENV UID=1000
+ENV GID=1000
+RUN addgroup -g $UID appgroup && \
+    adduser -u $GID -G appgroup -D appuser && \
+    chown -R appuser:appgroup /app
+USER appuser
 
 ENTRYPOINT ["python", "-m", "src.main"]

--- a/README.md
+++ b/README.md
@@ -175,13 +175,21 @@ python3 -m pytest tests/test_bot.py -v
 ### Build Image
 
 ```bash
-./.devops/Telegram-build.sh
+docker build -f .devops/Telegram.Dockerfile -t ghcr.io/olegshulyakov/go-briefly-bot .
 ```
 
 ### Run Container
 
 ```bash
-./.devops/Telegram-run.sh
+# Using docker run
+docker run -d \
+  --name go-briefly-bot \
+  -e TELEGRAM_BOT_TOKEN=your_token \
+  -e OPENAI_BASE_URL=https://api.openai.com/v1/ \
+  -e OPENAI_API_KEY=your_key \
+  -e OPENAI_MODEL=gpt3.5-turbo \
+  -e VALKEY_URL=valkey://valkey:6379 \
+  ghcr.io/olegshulyakov/go-briefly-bot
 ```
 
 ### Docker Compose


### PR DESCRIPTION
- Change Docker image name to GitHub Container Registry (ghcr.io/olegshulyakov/go-briefly-bot)
- Optimize Docker layer caching by copying pyproject.toml before source code
- Add security hardening by running container as non-root user (appuser)

BREAKING CHANGE: Docker image name changed from "go-briefly-telegram" to "ghcr.io/olegshulyakov/go-briefly-bot". Existing deployments referencing the old image name need to be updated.