### PR TITLE
feat(cache): add compression support for Valkey cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ YT_DLP_ADDITIONAL_OPTIONS=
 # If set, Valkey cache is used with 1 day TTL
 VALKEY_URL=
 
+# Cache Compression (Valkey only)
+# Options: none, gzip, zlib, lzma
+# Default: gzip (recommended balance of speed and compression)
+CACHE_COMPRESSION_METHOD=gzip
+
 # OpenAI-compatible API
 OPENAI_BASE_URL=https://api.openai.com/v1/
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Press `F5` to start debugging. Available configurations:
 | `VALKEY_URL`                   | Valkey connection URL (optional)   | —                                |
 | `CACHE_SUMMARY_TTL_SECONDS`    | TTL for cached summaries           | `3600` (local), `86400` (Valkey) |
 | `CACHE_TRANSCRIPT_TTL_SECONDS` | TTL for cached transcripts         | `3600` (local), `86400` (Valkey) |
+| `CACHE_COMPRESSION_METHOD`     | Compression for Valkey cache       | `gzip` (none, gzip, zlib, lzma)  |
 | `LOG_LEVEL`                    | Logging level                      | `INFO`                           |
 
 ## Tests

--- a/src/bot.py
+++ b/src/bot.py
@@ -80,7 +80,10 @@ class TelegramBrieflyBot:
 
         self.settings = settings
         if settings.valkey_url:
-            self.provider: CacheProvider = ValkeyProvider(settings.valkey_url)
+            self.provider: CacheProvider = ValkeyProvider(
+                settings.valkey_url,
+                compression_method=settings.cache_compression_method,
+            )
         else:
             self.provider: CacheProvider = LocalCacheProvider()
 

--- a/src/config.py
+++ b/src/config.py
@@ -32,6 +32,7 @@ class Settings:
         rate_limit_window_seconds: Cooldown between user requests.
         cache_summary_ttl_seconds: TTL for cached video summaries (in seconds). Defaults to 1 hour for local cache, 1 day for Valkey.
         cache_transcript_ttl_seconds: TTL for cached video transcripts (in seconds). Defaults to 1 hour for local cache, 1 day for Valkey.
+        cache_compression_method: Compression method for Valkey cache (none, gzip, zlib, lzma).
         max_telegram_message_length: Maximum message length before chunking.
         openai_timeout_seconds: Timeout for LLM API requests.
         openai_max_retries: Maximum retry attempts for LLM API.
@@ -45,6 +46,7 @@ class Settings:
     valkey_url: str | None = None
     cache_summary_ttl_seconds: int = 86400
     cache_transcript_ttl_seconds: int = 86400
+    cache_compression_method: str = "gzip"
     rate_limit_window_seconds: int = 10
     max_telegram_message_length: int = 3500
     openai_timeout_seconds: int = 300
@@ -86,6 +88,11 @@ class Settings:
         except ValueError:
             cache_transcript_ttl = default_transcript_ttl
 
+        cache_compression = os.getenv("CACHE_COMPRESSION_METHOD", "gzip").strip().lower()
+        valid_compression_methods = {"none", "gzip", "zlib", "lzma"}
+        if cache_compression not in valid_compression_methods:
+            cache_compression = "gzip"
+
         try:
             rate_limit_window = int(os.getenv("RATE_LIMIT_WINDOW_SECONDS", "10"))
         except ValueError:
@@ -112,6 +119,7 @@ class Settings:
             valkey_url=valkey_url,
             cache_summary_ttl_seconds=cache_summary_ttl,
             cache_transcript_ttl_seconds=cache_transcript_ttl,
+            cache_compression_method=cache_compression,
             rate_limit_window_seconds=rate_limit_window,
             yt_dlp_additional_options=yt_dlp_additional_options,
         )

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,3 +3,15 @@ Utilities module.
 
 Provides helper functions for text processing and formatting.
 """
+
+from .compression import CompressionMethod, compress, decompress
+from .markdown import markdown_to_telegram_html
+from .text import to_lexical_chunks
+
+__all__ = [
+    "CompressionMethod",
+    "compress",
+    "decompress",
+    "markdown_to_telegram_html",
+    "to_lexical_chunks",
+]

--- a/src/utils/compression.py
+++ b/src/utils/compression.py
@@ -1,0 +1,134 @@
+"""
+Compression utilities for cache data.
+
+Supports multiple compression algorithms with automatic detection
+via method prefix stored alongside the data.
+"""
+
+import gzip
+import lzma
+import zlib
+from enum import Enum
+
+
+class CompressionMethod(Enum):
+    """Supported compression methods."""
+
+    NONE = "none"
+    GZIP = "gzip"
+    ZLIB = "zlib"
+    LZMA = "lzma"
+
+
+# Prefix byte to identify compression method (stored as first byte of compressed data)
+COMPRESSION_PREFIXES = {
+    CompressionMethod.NONE: b"\x00",
+    CompressionMethod.GZIP: b"\x01",
+    CompressionMethod.ZLIB: b"\x02",
+    CompressionMethod.LZMA: b"\x03",
+}
+
+# Reverse mapping for decompression
+PREFIX_TO_METHOD = {v: k for k, v in COMPRESSION_PREFIXES.items()}
+
+
+class CompressionError(Exception):
+    """Raised when compression/decompression fails."""
+
+    pass
+
+
+def compress(data: bytes, method: CompressionMethod = CompressionMethod.GZIP) -> bytes:
+    """
+    Compress data with the specified method.
+
+    Args:
+        data: Raw bytes to compress.
+        method: Compression algorithm to use.
+
+    Returns:
+        Compressed bytes with method prefix.
+
+    Raises:
+        CompressionError: If compression fails.
+    """
+    if method == CompressionMethod.NONE:
+        return COMPRESSION_PREFIXES[CompressionMethod.NONE] + data
+
+    try:
+        if method == CompressionMethod.GZIP:
+            compressed = gzip.compress(data, compresslevel=6)
+        elif method == CompressionMethod.ZLIB:
+            compressed = zlib.compress(data, level=6)
+        elif method == CompressionMethod.LZMA:
+            compressed = lzma.compress(data, format=lzma.FORMAT_XZ, check=lzma.CHECK_CRC64)
+        else:
+            raise CompressionError(f"Unknown compression method: {method}")
+
+        return COMPRESSION_PREFIXES[method] + compressed
+    except Exception as e:
+        raise CompressionError(f"Compression failed with {method.value}: {e}")
+
+
+def decompress(data: bytes) -> bytes:
+    """
+    Decompress data, automatically detecting the compression method.
+
+    Args:
+        data: Compressed bytes with method prefix.
+
+    Returns:
+        Decompressed raw bytes.
+
+    Raises:
+        CompressionError: If decompression fails or method is unknown.
+    """
+    if not data:
+        return data
+
+    prefix = data[0:1]
+    method = PREFIX_TO_METHOD.get(prefix)
+
+    if method is None:
+        raise CompressionError(f"Unknown compression prefix: {prefix!r}")
+
+    payload = data[1:]
+
+    try:
+        if method == CompressionMethod.NONE:
+            return payload
+        elif method == CompressionMethod.GZIP:
+            return gzip.decompress(payload)
+        elif method == CompressionMethod.ZLIB:
+            return zlib.decompress(payload)
+        elif method == CompressionMethod.LZMA:
+            return lzma.decompress(payload)
+        else:
+            raise CompressionError(f"Unknown compression method: {method}")
+    except Exception as e:
+        raise CompressionError(f"Decompression failed: {e}")
+
+
+def get_compression_stats(original: bytes, compressed: bytes) -> dict:
+    """
+    Calculate compression statistics.
+
+    Args:
+        original: Original data size in bytes.
+        compressed: Compressed data size in bytes.
+
+    Returns:
+        Dictionary with compression ratio and savings.
+    """
+    if len(original) == 0:
+        return {"ratio": 0.0, "savings_percent": 0.0, "original_size": 0, "compressed_size": len(compressed)}
+
+    ratio = len(compressed) / len(original)
+    savings_percent = (1 - ratio) * 100
+
+    return {
+        "ratio": round(ratio, 3),
+        "savings_percent": round(savings_percent, 2),
+        "original_size": len(original),
+        "compressed_size": len(compressed),
+    }

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -1,0 +1,167 @@
+"""
+Tests for cache compression utilities.
+"""
+
+import pytest
+
+from src.utils.compression import (
+    CompressionMethod,
+    CompressionError,
+    compress,
+    decompress,
+    get_compression_stats,
+    COMPRESSION_PREFIXES,
+)
+
+
+class TestCompressionMethods:
+    """Test compression and decompression for all supported methods."""
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            CompressionMethod.NONE,
+            CompressionMethod.GZIP,
+            CompressionMethod.ZLIB,
+            CompressionMethod.LZMA,
+        ],
+    )
+    def test_compress_decompress_roundtrip(self, method):
+        """Test that data can be compressed and decompressed back to original."""
+        original_data = b"Hello, World! This is a test string for compression."
+        compressed = compress(original_data, method)
+        decompressed = decompress(compressed)
+        assert decompressed == original_data
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            CompressionMethod.GZIP,
+            CompressionMethod.ZLIB,
+            CompressionMethod.LZMA,
+        ],
+    )
+    def test_compression_savings(self, method):
+        """Test that compression actually reduces data size for reasonable input."""
+        # Create repetitive text that compresses well
+        original_data = b"A" * 1000 + b"B" * 1000 + b"C" * 1000
+        compressed = compress(original_data, method)
+        # Should compress to less than original (including prefix byte)
+        assert len(compressed) < len(original_data)
+
+    def test_none_compression_no_savings(self):
+        """Test that NONE method adds only prefix byte."""
+        original_data = b"Test data"
+        compressed = compress(original_data, CompressionMethod.NONE)
+        assert len(compressed) == len(original_data) + 1  # +1 for prefix
+
+    def test_empty_data(self):
+        """Test compression of empty data."""
+        original_data = b""
+        compressed = compress(original_data, CompressionMethod.GZIP)
+        decompressed = decompress(compressed)
+        assert decompressed == original_data
+
+    def test_large_data(self):
+        """Test compression of larger data."""
+        original_data = b"Hello World! " * 10000
+        compressed = compress(original_data, CompressionMethod.GZIP)
+        decompressed = decompress(compressed)
+        assert decompressed == original_data
+        # Should achieve significant compression
+        assert len(compressed) < len(original_data) * 0.1  # At least 90% compression
+
+    def test_binary_data(self):
+        """Test compression of binary data."""
+        original_data = bytes(range(256)) * 100
+        compressed = compress(original_data, CompressionMethod.GZIP)
+        decompressed = decompress(compressed)
+        assert decompressed == original_data
+
+    def test_unicode_text(self):
+        """Test compression of Unicode text."""
+        original_data = "Привет мир! Hello world! 你好世界!".encode("utf-8")
+        compressed = compress(original_data, CompressionMethod.GZIP)
+        decompressed = decompress(compressed)
+        assert decompressed == original_data
+
+
+class TestCompressionPrefixes:
+    """Test compression method prefixes."""
+
+    def test_all_methods_have_unique_prefixes(self):
+        """Test that each compression method has a unique prefix."""
+        prefixes = list(COMPRESSION_PREFIXES.values())
+        assert len(prefixes) == len(set(prefixes)), "Duplicate prefixes found"
+
+    def test_prefix_is_first_byte(self):
+        """Test that prefix is stored as first byte."""
+        for method, expected_prefix in COMPRESSION_PREFIXES.items():
+            compressed = compress(b"test data", method)
+            assert compressed[0:1] == expected_prefix
+
+
+class TestDecompressionErrors:
+    """Test decompression error handling."""
+
+    def test_unknown_prefix_raises_error(self):
+        """Test that unknown prefix raises CompressionError."""
+        with pytest.raises(CompressionError, match="Unknown compression prefix"):
+            decompress(b"\xffinvalid data")
+
+    def test_empty_data_returns_empty(self):
+        """Test that empty data returns empty."""
+        assert decompress(b"") == b""
+
+    def test_corrupted_data_raises_error(self):
+        """Test that corrupted data raises CompressionError."""
+        # Create valid compressed data then corrupt it
+        original = b"test data"
+        compressed = compress(original, CompressionMethod.GZIP)
+        # Corrupt the payload (keep prefix intact)
+        corrupted = compressed[0:1] + b"corrupted" + compressed[5:]
+        with pytest.raises(CompressionError, match="Decompression failed"):
+            decompress(corrupted)
+
+
+class TestCompressionStats:
+    """Test compression statistics calculation."""
+
+    def test_stats_calculation(self):
+        """Test compression stats are calculated correctly."""
+        original = b"A" * 1000
+        compressed = compress(original, CompressionMethod.GZIP)
+        stats = get_compression_stats(original, compressed)
+
+        assert "ratio" in stats
+        assert "savings_percent" in stats
+        assert "original_size" in stats
+        assert "compressed_size" in stats
+        assert stats["original_size"] == 1000
+        assert stats["compressed_size"] == len(compressed)
+        assert 0 < stats["ratio"] < 1  # Should be compressed
+        assert stats["savings_percent"] > 0
+
+    def test_empty_original_data(self):
+        """Test stats with empty original data."""
+        stats = get_compression_stats(b"", b"compressed")
+        assert stats["ratio"] == 0.0
+        assert stats["savings_percent"] == 0.0
+        assert stats["original_size"] == 0
+
+    def test_compression_ratio_for_different_methods(self):
+        """Test that different methods achieve different compression ratios."""
+        original = b"Hello World! " * 1000
+
+        gzip_compressed = compress(original, CompressionMethod.GZIP)
+        zlib_compressed = compress(original, CompressionMethod.ZLIB)
+        lzma_compressed = compress(original, CompressionMethod.LZMA)
+
+        gzip_stats = get_compression_stats(original, gzip_compressed)
+        zlib_stats = get_compression_stats(original, zlib_compressed)
+        lzma_stats = get_compression_stats(original, lzma_compressed)
+
+        # All should achieve significant compression
+        assert gzip_stats["ratio"] < 0.1
+        assert zlib_stats["ratio"] < 0.1
+        assert lzma_stats["ratio"] < 0.1


### PR DESCRIPTION
- Add `CACHE_COMPRESSION_METHOD` environment variable (none, gzip, zlib, lzma)
- Implement compression utilities with automatic method detection via prefix bytes
- Update ValkeyProvider to compress summaries and transcripts before storage
- Include compression method in cache keys to prevent collisions between methods