### PR TITLE
Refactor: house keeping

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,9 +16,16 @@ fi
 
 # Run linter if ruff is available
 if python3 -c "import ruff" >/dev/null 2>&1; then
-  python3 -m ruff check src/ tests/
+  python3 -m ruff ruff format --diff --target-version=py311
+  python3 -m ruff check --target-version=py311
 else
   echo "⚠️  ruff is not installed, skipping lint."
+fi
+
+if python3 -c "import mypy" >/dev/null 2>&1; then
+  python3 -m mypy src/ tests/ --python-version 3.11
+else
+  echo "⚠️  mypy is not installed, skipping lint."
 fi
 
 echo "✅ Checks passed. Commit proceeding."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           ruff check --output-format=github --target-version=py311
 
+      - name: Lint code with MyPy
+        run: |
+          mypy src/ tests/ --python-version 3.11
+
       - name: Check code formatting with Ruff
         run: |
           ruff format --diff --target-version=py311

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,9 +24,13 @@
       "type": "shell",
       "command": "${workspaceFolder}/.venv/bin/python",
       "args": ["-m", "pytest", "tests/", "-v"],
-      "group": "test",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
       "problemMatcher": [],
-      "detail": "Run all Python tests using pytest."
+      "detail": "Run all Python tests using pytest.",
+      "dependsOn": ["python: lint"]
     },
     {
       "label": "python: lint",
@@ -34,13 +38,14 @@
       "command": "${workspaceFolder}/.venv/bin/python -m ruff check --fix && ${workspaceFolder}/.venv/bin/python -m mypy src/ tests/",
       "group": "build",
       "problemMatcher": [],
-      "detail": "Run ruff linter and mypy type checker for Python code."
+      "detail": "Run ruff linter and mypy type checker for Python code.",
+      "dependsOn": ["python: format"]
     },
     {
       "label": "python: format",
       "type": "shell",
       "command": "${workspaceFolder}/.venv/bin/python",
-      "args": ["-m", "ruff", "format"],
+      "args": ["-m", "ruff", "format", "--target-version=py311"],
       "group": "none",
       "problemMatcher": [],
       "detail": "Format Python code using ruff."

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,11 +31,10 @@
     {
       "label": "python: lint",
       "type": "shell",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "args": ["-m", "ruff", "check", "--fix"],
+      "command": "${workspaceFolder}/.venv/bin/python -m ruff check --fix && ${workspaceFolder}/.venv/bin/python -m mypy src/ tests/",
       "group": "build",
       "problemMatcher": [],
-      "detail": "Run ruff linter for Python code."
+      "detail": "Run ruff linter and mypy type checker for Python code."
     },
     {
       "label": "python: format",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This project is a Telegram bot written in Python designed to summarize video con
 1.  **`__init__.py` is an Entry Point:** It MUST ONLY contain re-exports or package wiring. No business logic or utility functions allowed here.
 2.  **No Catch-All Files:** Names like `utils.py`, `helpers.py`, or `services.py` are BANNED. Use domain-specific names (e.g., `yt_dlp_handler.py`, `date_formatter.py`).
 3.  **Single Responsibility Principle:** Every file MUST have one clear, nameable purpose. If you can't describe it in one phrase, split it.
-4.  **250 LOC Hard Limit:** Any file > 250 lines of logic (excluding docstrings/prompts) is a code smell and MUST be refactored immediately.
+4.  **300 LOC Hard Limit:** Any file > 300 lines of logic (excluding docstrings/prompts) is a code smell and MUST be refactored immediately.
 5.  **Refactor-First:** If a task requires touching a file that violates these rules, you MUST refactor it BEFORE adding new logic.
 
 ## Technologies Used

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dev = [
     "pytest>=8.0.0,<9.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.0.0",
+    "pytest-mock>=3.12.0",
+    "mypy>=1.8.0",
 ]
 
 test = [
@@ -57,12 +59,18 @@ Repository = "https://github.com/olegshulyakov/go-briefly-bot.git"
 Issues = "https://github.com/olegshulyakov/go-briefly-bot/issues"
 License = "https://github.com/olegshulyakov/go-briefly-bot/blob/main/LICENSE"
 
-[project.scripts]
-go-briefly-bot = "src.main:main"
+[tool.mypy]
+python_version = "3.11"
+strict = true
+ignore_missing_imports = true
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["src*"]
+[[tool.mypy.overrides]]
+module = "i18n.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "yt_dlp.*"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
@@ -82,3 +90,24 @@ exclude = [
     ".venv/",
     "venv/",
 ]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "B",    # flake8-bugbear
+    "C90",  # mccabe complexity
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "PL",   # pylint
+]
+ignore = []
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-branches = 12
+max-statements = 150

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ addopts = "-v --tb=short"
 
 [tool.ruff]
 target-version = "py311"
-line-length = 120
+line-length = 150
 src = ["src", "tests"]
 exclude = [
     ".githooks/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ ignore_missing_imports = true
 module = "yt_dlp.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "markdown.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ module = "markdown.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]

--- a/src/bot.py
+++ b/src/bot.py
@@ -89,8 +89,12 @@ class TelegramBrieflyBot:
         )
         await message.reply_text(translate("telegram.welcome.message", locale=language))
 
-    async def _handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:  # noqa: C901, PLR0911
-        """Handles incoming text messages, extracts URLs, loads video transcripts, summarizes them, and sends the summary back to the user."""
+    async def _handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handles incoming text messages asynchronously without blocking."""
+        asyncio.create_task(self._process_message(update, context))
+
+    async def _process_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:  # noqa: C901, PLR0911
+        """Extracts URLs, loads video transcripts, summarizes them, and sends the summary back to the user."""
 
         del context
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -16,7 +16,6 @@ import logging
 from telegram import LinkPreviewOptions, Update, User
 from telegram.constants import ParseMode
 from telegram.ext import (
-    Application,
     ApplicationBuilder,
     CommandHandler,
     ContextTypes,
@@ -55,7 +54,7 @@ class TelegramBrieflyBot:
         self.rate_limiter = UserRateLimiter(self.provider, settings.rate_limit_window_seconds)
         self.summarizer = OpenAISummarizer(settings)
 
-        self.application: Application = ApplicationBuilder().token(self.settings.telegram_bot_token).build()
+        self.application = ApplicationBuilder().token(self.settings.telegram_bot_token).build()
         self.application.add_handler(CommandHandler("start", self._start))
         self.application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message))
         self.application.add_error_handler(self._on_error)
@@ -89,7 +88,7 @@ class TelegramBrieflyBot:
         )
         await message.reply_text(translate("telegram.welcome.message", locale=language))
 
-    async def _handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:  # noqa: C901, PLR0911
         """Handles incoming text messages, extracts URLs, loads video transcripts, summarizes them, and sends the summary back to the user."""
 
         del context

--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -3,11 +3,14 @@ Cache providers namespace for Go Briefly Bot.
 """
 
 from .base import CacheProvider
+from .factory import get_cache_provider, reset_cache_provider
 from .local import LocalCacheProvider
 from .valkey import ValkeyProvider
 
 __all__ = [
     "CacheProvider",
+    "get_cache_provider",
+    "reset_cache_provider",
     "LocalCacheProvider",
     "ValkeyProvider",
 ]

--- a/src/cache/base.py
+++ b/src/cache/base.py
@@ -4,9 +4,21 @@ Base cache provider interface for Go Briefly Bot.
 
 from abc import ABC, abstractmethod
 
+from src.utils.compression import CompressionMethod
+
 
 class CacheProvider(ABC):
     """Abstract base class for cache providers (cache and rate limiting)."""
+
+    def _parse_compression_method(self, method: str) -> CompressionMethod:
+        """Parse compression method string to enum."""
+        method_map = {
+            "none": CompressionMethod.NONE,
+            "gzip": CompressionMethod.GZIP,
+            "zlib": CompressionMethod.ZLIB,
+            "lzma": CompressionMethod.LZMA,
+        }
+        return method_map.get(method.lower(), CompressionMethod.GZIP)
 
     @abstractmethod
     async def is_rate_limited(self, user_id: int, window_seconds: int) -> bool:
@@ -23,21 +35,21 @@ class CacheProvider(ABC):
         pass
 
     @abstractmethod
-    async def get_summary(self, video_hash: str, language_code: str | None) -> str | None:
-        """Retrieves a cached summary for a video."""
+    async def put(self, key: str, text: str, ttl_seconds: int) -> None:
+        """Caches a text."""
         pass
 
     @abstractmethod
-    async def set_summary(self, video_hash: str, language_code: str | None, summary: str, ttl_seconds: int) -> None:
-        """Caches a summary for a video."""
+    async def get(self, key: str) -> str | None:
+        """Retrieves a cached text."""
         pass
 
     @abstractmethod
-    async def get_transcript(self, video_hash: str) -> dict | None:
-        """Retrieves a cached transcript dict for a video."""
+    async def get_dict(self, key: str) -> dict | None:
+        """Retrieves a cached dict."""
         pass
 
     @abstractmethod
-    async def set_transcript(self, video_hash: str, transcript_data: dict, ttl_seconds: int) -> None:
-        """Caches a transcript dict for a video."""
+    async def put_dict(self, key: str, data: dict, ttl_seconds: int) -> None:
+        """Caches a dict."""
         pass

--- a/src/cache/base.py
+++ b/src/cache/base.py
@@ -3,6 +3,7 @@ Base cache provider interface for Go Briefly Bot.
 """
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from src.utils.compression import CompressionMethod
 
@@ -45,11 +46,11 @@ class CacheProvider(ABC):
         pass
 
     @abstractmethod
-    async def get_dict(self, key: str) -> dict | None:
+    async def get_dict(self, key: str) -> dict[str, Any] | None:
         """Retrieves a cached dict."""
         pass
 
     @abstractmethod
-    async def put_dict(self, key: str, data: dict, ttl_seconds: int) -> None:
+    async def put_dict(self, key: str, data: dict[str, Any], ttl_seconds: int) -> None:
         """Caches a dict."""
         pass

--- a/src/cache/factory.py
+++ b/src/cache/factory.py
@@ -1,0 +1,56 @@
+"""
+Cache provider factory helpers.
+
+Creates cache providers based on application settings.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+
+from ..config import Settings
+from .base import CacheProvider
+from .local import LocalCacheProvider
+from .valkey import ValkeyProvider
+
+_provider_lock = Lock()
+_provider: CacheProvider | None = None
+
+
+def get_cache_provider(settings: Settings) -> CacheProvider:
+    """
+    Build or return a cached cache provider instance.
+
+    Args:
+        settings: Application settings with cache configuration.
+
+    Returns:
+        Cache provider instance.
+    """
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    with _provider_lock:
+        if _provider is not None:
+            return _provider
+
+        if settings.valkey_url:
+            _provider = ValkeyProvider(
+                settings.valkey_url,
+                compression_method=settings.cache_compression_method,
+            )
+        else:
+            _provider = LocalCacheProvider()
+
+    return _provider
+
+
+def reset_cache_provider() -> None:
+    """
+    Reset the cached cache provider.
+
+    Intended for tests to avoid cross-test state sharing.
+    """
+    global _provider
+    _provider = None

--- a/src/cache/valkey.py
+++ b/src/cache/valkey.py
@@ -87,7 +87,8 @@ class ValkeyProvider(CacheProvider):
                     logger.warning(f"Failed to decompress/decode cached string: {e}")
             return None
 
-        return await self._safe_execute(_valkey_get)
+        res: str | None = await self._safe_execute(_valkey_get)
+        return res
 
     async def put(self, key: str, text: str, ttl_seconds: int) -> None:
         async def _valkey_set() -> None:
@@ -98,22 +99,24 @@ class ValkeyProvider(CacheProvider):
 
         await self._safe_execute(_valkey_set)
 
-    async def get_dict(self, key: str) -> dict | None:
-        async def _valkey_get() -> dict | None:
+    async def get_dict(self, key: str) -> dict[str, Any] | None:
+        async def _valkey_get() -> dict[str, Any] | None:
             client = await self._get_client()
             cache_key = f"{key}:{self._compression_method.value}"
             val = await client.get(cache_key)
             if val is not None:
                 try:
                     decompressed = decompress(val)
-                    return json.loads(decompressed.decode("utf-8"))
+                    res_dict: dict[str, Any] = json.loads(decompressed.decode("utf-8"))
+                    return res_dict
                 except Exception as e:
                     logger.warning(f"Failed to decompress/decode cached dict: {e}")
             return None
 
-        return await self._safe_execute(_valkey_get)
+        res: dict[str, Any] | None = await self._safe_execute(_valkey_get)
+        return res
 
-    async def put_dict(self, key: str, data: dict, ttl_seconds: int) -> None:
+    async def put_dict(self, key: str, data: dict[str, Any], ttl_seconds: int) -> None:
         async def _valkey_set() -> None:
             client = await self._get_client()
             cache_key = f"{key}:{self._compression_method.value}"

--- a/src/cache/valkey.py
+++ b/src/cache/valkey.py
@@ -13,7 +13,6 @@ from valkey.asyncio import Valkey
 from valkey.exceptions import ConnectionError as ValkeyConnectionError
 
 from ..utils import compress, decompress
-
 from .base import CacheProvider
 
 logger = logging.getLogger(__name__)
@@ -42,7 +41,7 @@ class ValkeyProvider(CacheProvider):
     async def _safe_execute(self, coro_fn: Any) -> Any:
         try:
             return await asyncio.wait_for(coro_fn(), timeout=self._timeout)
-        except (TimeoutError, asyncio.TimeoutError):
+        except TimeoutError:
             logger.warning("Valkey timeout")
             return None
         except (ValkeyConnectionError, ConnectionError, OSError) as e:

--- a/src/config.py
+++ b/src/config.py
@@ -53,7 +53,7 @@ class Settings:
     openai_max_retries: int = 3
 
     @classmethod
-    def from_env(cls) -> "Settings":
+    def from_env(cls) -> Settings:
         """
         Load settings from environment variables.
 

--- a/src/load/video_loader.py
+++ b/src/load/video_loader.py
@@ -9,7 +9,6 @@ This module provides functionality to:
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
 import tempfile
@@ -26,6 +25,7 @@ from .video_provider import build_video_source
 
 logger = logging.getLogger(__name__)
 max_attempts = 3
+cache_prefix = "transcript:"
 
 
 def _is_safe_option_value(value: str) -> bool:
@@ -99,45 +99,52 @@ class VideoDataLoader:
     temporary file management, and subtitle cleaning.
     """
 
-    def __init__(self, url: str, settings: Settings) -> None:
+    def __init__(self, settings: Settings) -> None:
         """
         Initialize the video loader.
 
         Args:
-            url: Video URL to process.
             settings: Application settings with cache and yt-dlp configuration.
         """
-        self.url, self.video_id = build_video_source(url)
         self.settings = settings
         self.cache_provider: CacheProvider = get_cache_provider(settings)
         self.yt_dlp_additional_options = settings.yt_dlp_additional_options
-        self.info: VideoInfo | None = None
-        self.transcript: VideoTranscript | None = None
 
-    async def load(self) -> VideoTranscript | None:
+    async def load(self, url: str) -> VideoTranscript:
         """
         Load transcript.
 
+        Args:
+            url: Video URL to process.
+
         Returns:
-            VideoTranscript if available, otherwise None.
+            VideoTranscript if available, otherwise raise exception.
+
+        Throws:
+            - `RuntimeError` - video info/subtitles failed
+            - `FileNotFoundError` - no subtitles
+            - `ValueError` - URL is not valid
+            - `OSError` - failed to clean up temporary files
         """
-        cache_key = f"transcript:{self._video_hash}"
+        url, video_id = build_video_source(url)
+        cache_key = f"{cache_prefix}:{self._get_video_hash(url)}"
         cached_transcript = await self.cache_provider.get_dict(cache_key)
         if cached_transcript:
-            self.transcript = VideoTranscript(**cached_transcript)
-            logger.debug("Transcript loaded from cache", extra={"url": self.url})
-            return self.transcript
+            transcript = VideoTranscript(**cached_transcript)
+            logger.debug("Transcript loaded from cache", extra={"url": url})
+            return transcript
 
-        await asyncio.to_thread(self._load)
-        if self.transcript:
-            await self.cache_provider.put_dict(
-                cache_key,
-                asdict(self.transcript),
-                self.settings.cache_transcript_ttl_seconds,
-            )
-        return self.transcript
+        transcript = self._load(url, video_id)
 
-    def _load(self) -> None:
+        await self.cache_provider.put_dict(
+            cache_key,
+            asdict(transcript),
+            self.settings.cache_transcript_ttl_seconds,
+        )
+
+        return transcript
+
+    def _load(self, url: str, video_id: str) -> VideoTranscript:
         """
         Load video info and download transcript.
 
@@ -155,8 +162,8 @@ class VideoDataLoader:
         logger.info(
             "Loading video info",
             extra={
-                "url": self.url,
-                "video_id": self.video_id,
+                "url": url,
+                "video_id": video_id,
             },
         )
 
@@ -170,8 +177,8 @@ class VideoDataLoader:
                     }
                 )
                 with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                    raw_info = ydl.extract_info(self.url, download=False)
-                    self.info = VideoInfo(
+                    raw_info = ydl.extract_info(url, download=False)
+                    info = VideoInfo(
                         id=str(raw_info.get("id", "")),
                         language=str(raw_info.get("language", "") or ""),
                         uploader=str(raw_info.get("uploader", "") or ""),
@@ -184,13 +191,13 @@ class VideoDataLoader:
                 last_error = exc
                 logger.warning(
                     "Failed to load video info",
-                    extra={"attempt": attempt + 1, "url": self.url, "error": str(exc)},
+                    extra={"attempt": attempt + 1, "url": url, "error": str(exc)},
                 )
         else:
             raise RuntimeError(f"Failed to load video info after {max_attempts} attempts: {last_error}")
 
-        language = self._detect_language(self.info)
-        logger.debug("Detected transcript language", extra={"url": self.url, "language": language})
+        language = self._detect_language(info)
+        logger.debug("Detected transcript language", extra={"url": url, "language": language})
 
         # Download subtitles with retries
         for attempt in range(max_attempts):
@@ -203,41 +210,43 @@ class VideoDataLoader:
                         "writeautomaticsub": True,
                         "subtitleslangs": [language, f"{language}_auto", "-live_chat"],
                         "subtitlesformat": "srt",
-                        "outtmpl": self._subtitle_template_path,
+                        "outtmpl": self._get_subtitle_template_path(video_id),
                     }
                 )
                 with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                    ydl.extract_info(self.url, download=True)
+                    ydl.extract_info(url, download=True)
                 break
             except Exception as exc:
                 last_error = exc
                 logger.warning(
                     "Failed to download subtitles",
-                    extra={"attempt": attempt + 1, "url": self.url, "error": str(exc)},
+                    extra={"attempt": attempt + 1, "url": url, "error": str(exc)},
                 )
         else:
             raise RuntimeError(f"Failed to download subtitles after {max_attempts} attempts: {last_error}")
 
-        subtitle_file = self._find_subtitle_file(language)
+        subtitle_file = self._find_subtitle_file(video_id, language)
         if subtitle_file is None:
-            logger.warning("No subtitles found", extra={"url": self.url, "language": language})
+            logger.warning("No subtitles found", extra={"url": url, "language": language})
             raise FileNotFoundError("no subtitles found")
 
         raw_transcript = subtitle_file.read_text(encoding="utf-8", errors="ignore")
         transcript_text = clean_srt(raw_transcript)
 
-        self.transcript = VideoTranscript(
-            id=self.info.id,
+        transcript = VideoTranscript(
+            id=info.id,
             language=language,
-            uploader=self.info.uploader,
-            title=self.info.title,
-            thumbnail=self.info.thumbnail,
+            uploader=info.uploader,
+            title=info.title,
+            thumbnail=info.thumbnail,
             transcript=transcript_text,
         )
 
-        logger.info("Transcript loaded successfully", extra={"url": self.url, "length": len(transcript_text)})
+        logger.info("Transcript loaded successfully", extra={"url": url, "length": len(transcript_text)})
 
-        self._cleanup_subtitle_files()
+        self._cleanup_subtitle_files(video_id)
+
+        return transcript
 
     def _build_ydl_opts(self, extra_options: dict[str, Any] | None = None) -> dict[str, Any]:
         """
@@ -284,21 +293,18 @@ class VideoDataLoader:
             i += 1
         return opts
 
-    @property
-    def _video_hash(self) -> str:
+    def _get_video_hash(self, url: str) -> str:
         """Return the cache key for this video URL."""
-        return hashlib.sha256(self.url.encode("utf-8")).hexdigest()
+        return hashlib.sha256(url.encode("utf-8")).hexdigest()
 
-    @property
-    def _subtitle_template_path(self) -> str:
+    def _get_subtitle_template_path(self, video_id: str) -> str:
         """Generate template path for subtitle files in temp directory."""
         temp_dir = Path(tempfile.gettempdir())
-        return str(temp_dir / f"subtitles_{self.video_id}.%(ext)s")
+        return str(temp_dir / f"subtitles_{video_id}.%(ext)s")
 
-    @property
-    def _subtitle_prefix(self) -> Path:
+    def _get_subtitle_prefix(self, video_id: str) -> Path:
         """Get prefix for subtitle file names in temp directory."""
-        return Path(tempfile.gettempdir()) / f"subtitles_{self.video_id}"
+        return Path(tempfile.gettempdir()) / f"subtitles_{video_id}"
 
     def _detect_language(self, info: VideoInfo) -> str:
         """
@@ -331,7 +337,7 @@ class VideoDataLoader:
         # Get first available language from subtitles
         return next(iter(info.subtitles.keys())).split("-", maxsplit=1)[0]
 
-    def _find_subtitle_file(self, language: str) -> Path | None:
+    def _find_subtitle_file(self, video_id: str, language: str) -> Path | None:
         """
         Find downloaded subtitle file for the given language.
 
@@ -346,20 +352,20 @@ class VideoDataLoader:
         Returns:
             Path to subtitle file or None if not found.
         """
-        exact = self._subtitle_prefix.with_suffix(f".{language}.srt")
+        exact = self._get_subtitle_prefix(video_id).with_suffix(f".{language}.srt")
         if exact.exists():
             return exact
 
-        auto = self._subtitle_prefix.with_suffix(f".{language}_auto.srt")
+        auto = self._get_subtitle_prefix(video_id).with_suffix(f".{language}_auto.srt")
         if auto.exists():
             return auto
 
-        candidates = sorted(Path(tempfile.gettempdir()).glob(f"subtitles_{self.video_id}*.srt"))
+        candidates = sorted(Path(tempfile.gettempdir()).glob(f"subtitles_{video_id}*.srt"))
         return candidates[0] if candidates else None
 
-    def _cleanup_subtitle_files(self) -> None:
+    def _cleanup_subtitle_files(self, video_id: str) -> None:
         """Remove temporary subtitle files for this video."""
-        for path in Path(tempfile.gettempdir()).glob(f"subtitles_{self.video_id}*"):
+        for path in Path(tempfile.gettempdir()).glob(f"subtitles_{video_id}*"):
             try:
                 path.unlink(missing_ok=True)
             except OSError:

--- a/src/load/video_loader.py
+++ b/src/load/video_loader.py
@@ -15,6 +15,7 @@ import logging
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
 
 import yt_dlp
 
@@ -238,7 +239,7 @@ class VideoDataLoader:
 
         self._cleanup_subtitle_files()
 
-    def _build_ydl_opts(self, extra_options: dict | None = None) -> dict:
+    def _build_ydl_opts(self, extra_options: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Build yt-dlp options with additional user options.
 
@@ -252,7 +253,7 @@ class VideoDataLoader:
             User-provided options are filtered to prevent injection attacks.
             Only safe options (starting with --) are allowed.
         """
-        opts = {
+        opts: dict[str, Any] = {
             "quiet": True,
             "no_warnings": True,
             "extract_flat": False,

--- a/src/load/video_loader.py
+++ b/src/load/video_loader.py
@@ -267,9 +267,7 @@ class VideoDataLoader:
             if opt.startswith("--"):
                 key = opt[2:].replace("-", "_")
                 # Check if next option is a value (not another flag)
-                if i + 1 < len(self.yt_dlp_additional_options) and not self.yt_dlp_additional_options[i + 1].startswith(
-                    "--"
-                ):
+                if i + 1 < len(self.yt_dlp_additional_options) and not self.yt_dlp_additional_options[i + 1].startswith("--"):
                     value = self.yt_dlp_additional_options[i + 1]
                     # Validate value to prevent injection attacks
                     if not _is_safe_option_value(value):

--- a/src/load/yt_dlp_logger.py
+++ b/src/load/yt_dlp_logger.py
@@ -1,5 +1,6 @@
 """Module for capturing yt-dlp log output."""
 
+
 class YtDlpCaptureLogger:
     """Captures yt-dlp log output for debugging."""
 

--- a/src/load/yt_dlp_logger.py
+++ b/src/load/yt_dlp_logger.py
@@ -1,0 +1,24 @@
+"""Module for capturing yt-dlp log output."""
+
+class YtDlpCaptureLogger:
+    """Captures yt-dlp log output for debugging."""
+
+    def __init__(self) -> None:
+        """Initialize the capture logger."""
+        self.messages: list[str] = []
+
+    def debug(self, msg: str) -> None:
+        """Capture debug message."""
+        self.messages.append(f"[debug] {msg}")
+
+    def info(self, msg: str) -> None:
+        """Capture info message."""
+        self.messages.append(f"[info] {msg}")
+
+    def warning(self, msg: str) -> None:
+        """Capture warning message."""
+        self.messages.append(f"[warning] {msg}")
+
+    def error(self, msg: str) -> None:
+        """Capture error message."""
+        self.messages.append(f"[error] {msg}")

--- a/src/localization.py
+++ b/src/localization.py
@@ -13,7 +13,12 @@ import i18n
 
 DEFAULT_LOCALE = "en"
 
-_initialized = False
+
+class I18nState:
+    is_initialized: bool = False
+
+
+_state = I18nState()
 
 
 def _setup_i18n() -> None:
@@ -26,8 +31,7 @@ def _setup_i18n() -> None:
     - Fallback locale
     - Memoization for performance
     """
-    global _initialized
-    if _initialized:
+    if _state.is_initialized:
         return
 
     locales_path = Path(__file__).resolve().parents[1] / "locales"
@@ -39,7 +43,7 @@ def _setup_i18n() -> None:
     i18n.set("locale", DEFAULT_LOCALE)
     i18n.set("enable_memoization", True)
 
-    _initialized = True
+    _state.is_initialized = True
 
 
 def normalize_locale(locale: str | None) -> str:

--- a/src/localization.py
+++ b/src/localization.py
@@ -42,7 +42,7 @@ def _setup_i18n() -> None:
     _initialized = True
 
 
-def _normalize_locale(locale: str | None) -> str:
+def normalize_locale(locale: str | None) -> str:
     """
     Normalize a locale code to base language.
 
@@ -85,7 +85,7 @@ def translate(key: str, locale: str | None = None, **kwargs: object) -> str:
     """
     _setup_i18n()
 
-    lang = _normalize_locale(locale)
+    lang = normalize_locale(locale)
     for candidate in (lang, DEFAULT_LOCALE):
         try:
             value = i18n.t(key, locale=candidate, **kwargs)

--- a/src/logger.py
+++ b/src/logger.py
@@ -53,11 +53,7 @@ class CustomFormatter(logging.Formatter):
             "asctime",
             "taskName",
         }
-        extra_fields = {
-            key: value
-            for key, value in record.__dict__.items()
-            if key not in standard_attrs and not key.startswith("_")
-        }
+        extra_fields = {key: value for key, value in record.__dict__.items() if key not in standard_attrs and not key.startswith("_")}
         if extra_fields:
             extra_str = " ".join(f'{k}="{v}"' for k, v in extra_fields.items())
             return f"{base_message}: {extra_str}"

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ def main() -> None:
     logger.info("Starting application")
     settings = Settings.from_env()
     telegram = TelegramBrieflyBot(settings)
-    threading.Thread(target=telegram.run()).start()
+    threading.Thread(target=telegram.run).start()
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 
 from .bot import TelegramBrieflyBot
 from .config import Settings
@@ -19,7 +18,7 @@ def main() -> None:
     logger.info("Starting application")
     settings = Settings.from_env()
     telegram = TelegramBrieflyBot(settings)
-    threading.Thread(target=telegram.run).start()
+    telegram.run()
 
 
 if __name__ == "__main__":

--- a/src/rate_limiter.py
+++ b/src/rate_limiter.py
@@ -1,0 +1,37 @@
+"""
+User rate limiting helpers.
+
+Provides a per-user rate limiter backed by the cache provider.
+"""
+
+from __future__ import annotations
+
+from .cache import CacheProvider
+
+
+class UserRateLimiter:
+    """Limits the rate of requests for individual users."""
+
+    def __init__(self, provider: CacheProvider, cooldown_seconds: int) -> None:
+        """
+        Initializes the UserRateLimiter.
+
+        Args:
+            provider: The cache provider for state management.
+            cooldown_seconds: The cooldown period in seconds for each user.
+        """
+
+        self.provider = provider
+        self.cooldown_seconds = cooldown_seconds
+
+    async def is_limited(self, user_id: int) -> bool:
+        """
+        Checks if a user is rate-limited. If not, records the current request time.
+
+        Args:
+            user_id: The ID of the user to check.
+
+        Returns:
+            True if the user is rate-limited, False otherwise.
+        """
+        return await self.provider.is_rate_limited(user_id, self.cooldown_seconds)

--- a/src/transform/summarization.py
+++ b/src/transform/summarization.py
@@ -105,6 +105,9 @@ class OpenAISummarizer:
         )
         prompt = translate("openai.prompt", locale=locale, text=text)
 
+        if self.settings.openai_max_retries <= 0:
+            raise ValueError("openai_max_retries must be greater than 0")
+
         last_error: Exception | None = None
         for attempt in range(self.settings.openai_max_retries):
             try:

--- a/src/transform/summarization.py
+++ b/src/transform/summarization.py
@@ -7,7 +7,6 @@ timeout handling, and localization support.
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
 import time
@@ -19,6 +18,7 @@ from ..config import Settings
 from ..localization import translate
 
 logger = logging.getLogger(__name__)
+cache_prefix = "summary:"
 
 
 class OpenAISummarizer:
@@ -68,13 +68,13 @@ class OpenAISummarizer:
             raise ValueError("text must be a non-empty string")
 
         video_hash = self._text_hash(text)
-        cache_key = f"summary:{video_hash}:{locale}"
+        cache_key = f"{cache_prefix}:{video_hash}:{locale}"
         cached_summary = await self.cache_provider.get(cache_key)
         if cached_summary:
             logger.debug("Summary loaded from cache", extra={"locale": locale})
             return cached_summary
 
-        summary = await asyncio.to_thread(self._summarize, text, locale)
+        summary = self._summarize(text, locale)
         await self.cache_provider.put(
             cache_key,
             summary,

--- a/src/utils/compression.py
+++ b/src/utils/compression.py
@@ -9,6 +9,7 @@ import gzip
 import lzma
 import zlib
 from enum import Enum
+from typing import Any
 
 
 class CompressionMethod(Enum):
@@ -67,7 +68,7 @@ def compress(data: bytes, method: CompressionMethod = CompressionMethod.GZIP) ->
 
         return COMPRESSION_PREFIXES[method] + compressed
     except Exception as e:
-        raise CompressionError(f"Compression failed with {method.value}: {e}")
+        raise CompressionError(f"Compression failed with {method.value}: {e}") from e
 
 
 def decompress(data: bytes) -> bytes:
@@ -106,10 +107,10 @@ def decompress(data: bytes) -> bytes:
         else:
             raise CompressionError(f"Unknown compression method: {method}")
     except Exception as e:
-        raise CompressionError(f"Decompression failed: {e}")
+        raise CompressionError(f"Decompression failed: {e}") from e
 
 
-def get_compression_stats(original: bytes, compressed: bytes) -> dict:
+def get_compression_stats(original: bytes, compressed: bytes) -> dict[str, Any]:
     """
     Calculate compression statistics.
 

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -82,7 +82,7 @@ def _find_natural_breakpoint(text: str, left: int, right: int) -> int:
         return left + paragraph_idx + 1
 
     # Find the rightmost sentence boundary
-    sentence_idx = max(piece.rfind("."), max(piece.rfind("!"), piece.rfind("?")))
+    sentence_idx = max(piece.rfind("."), piece.rfind("!"), piece.rfind("?"))
     if sentence_idx > 0:
         return left + sentence_idx + 1
 

--- a/tests/cache/test_local.py
+++ b/tests/cache/test_local.py
@@ -1,6 +1,6 @@
 import asyncio
-import pytest
 
+import pytest
 from src.cache import LocalCacheProvider
 
 

--- a/tests/cache/test_local.py
+++ b/tests/cache/test_local.py
@@ -23,56 +23,56 @@ async def test_local_rate_limit(provider):
 @pytest.mark.asyncio
 async def test_local_summary_multiple_languages(provider):
     # Set summary in English
-    await provider.set_summary("hash123", "en", "english summary", 3600)
+    await provider.put("summary:hash123:en", "english summary", 3600)
     # Set summary in Spanish
-    await provider.set_summary("hash123", "ru", "spanish summary", 3600)
+    await provider.put("summary:hash123:es", "spanish summary", 3600)
 
     # Get English summary
-    summary_en = await provider.get_summary("hash123", "en")
-    assert summary_en == "english summary"
+    text_en = await provider.get("summary:hash123:en")
+    assert text_en == "english summary"
 
     # Get Spanish summary
-    summary_ru = await provider.get_summary("hash123", "ru")
-    assert summary_ru == "spanish summary"
+    text_es = await provider.get("summary:hash123:es")
+    assert text_es == "spanish summary"
 
     # Missing language
-    summary_fr = await provider.get_summary("hash123", "fr")
-    assert summary_fr is None
+    text_fr = await provider.get("summary:hash123:fr")
+    assert text_fr is None
 
 
 @pytest.mark.asyncio
 async def test_local_summary_expiration(provider):
     # Set with short TTL
-    await provider.set_summary("hash123", "en", "expiring summary", 0.1)
+    await provider.put("summary:hash123:en", "expiring summary", 0.1)
 
     # Should exist initially
-    assert await provider.get_summary("hash123", "en") == "expiring summary"
+    assert await provider.get("summary:hash123:en") == "expiring summary"
 
     # Wait for expiration
     await asyncio.sleep(0.2)
 
     # Should be gone
-    assert await provider.get_summary("hash123", "en") is None
+    assert await provider.get("summary:hash123:en") is None
 
 
 @pytest.mark.asyncio
 async def test_local_transcript(provider):
-    transcript_data = {"text": "hello"}
+    data = {"text": "hello"}
 
-    await provider.set_transcript("hash123", transcript_data, 3600)
+    await provider.put_dict("transcript:hash123", data, 3600)
 
-    result = await provider.get_transcript("hash123")
-    assert result == transcript_data
+    result = await provider.get_dict("transcript:hash123")
+    assert result == data
 
 
 @pytest.mark.asyncio
 async def test_local_transcript_expiration(provider):
-    transcript_data = {"text": "expiring"}
+    data = {"text": "expiring"}
 
-    await provider.set_transcript("hash123", transcript_data, 0.1)
+    await provider.put_dict("transcript:hash123", data, 0.1)
 
-    assert await provider.get_transcript("hash123") == transcript_data
+    assert await provider.get_dict("transcript:hash123") == data
 
     await asyncio.sleep(0.2)
 
-    assert await provider.get_transcript("hash123") is None
+    assert await provider.get_dict("transcript:hash123") is None

--- a/tests/cache/test_local.py
+++ b/tests/cache/test_local.py
@@ -5,12 +5,12 @@ from src.cache import LocalCacheProvider
 
 
 @pytest.fixture
-def provider():
+def provider() -> LocalCacheProvider:
     return LocalCacheProvider()
 
 
 @pytest.mark.asyncio
-async def test_local_rate_limit(provider):
+async def test_local_rate_limit(provider: LocalCacheProvider) -> None:
     # Not limited initially
     is_limited = await provider.is_rate_limited(123, 10)
     assert not is_limited
@@ -21,7 +21,7 @@ async def test_local_rate_limit(provider):
 
 
 @pytest.mark.asyncio
-async def test_local_summary_multiple_languages(provider):
+async def test_local_summary_multiple_languages(provider: LocalCacheProvider) -> None:
     # Set summary in English
     await provider.put("summary:hash123:en", "english summary", 3600)
     # Set summary in Spanish
@@ -41,22 +41,22 @@ async def test_local_summary_multiple_languages(provider):
 
 
 @pytest.mark.asyncio
-async def test_local_summary_expiration(provider):
+async def test_local_summary_expiration(provider: LocalCacheProvider) -> None:
     # Set with short TTL
-    await provider.put("summary:hash123:en", "expiring summary", 0.1)
+    await provider.put("summary:hash123:en", "expiring summary", 1)
 
     # Should exist initially
     assert await provider.get("summary:hash123:en") == "expiring summary"
 
     # Wait for expiration
-    await asyncio.sleep(0.2)
+    await asyncio.sleep(1.1)
 
     # Should be gone
     assert await provider.get("summary:hash123:en") is None
 
 
 @pytest.mark.asyncio
-async def test_local_transcript(provider):
+async def test_local_transcript(provider: LocalCacheProvider) -> None:
     data = {"text": "hello"}
 
     await provider.put_dict("transcript:hash123", data, 3600)
@@ -66,13 +66,13 @@ async def test_local_transcript(provider):
 
 
 @pytest.mark.asyncio
-async def test_local_transcript_expiration(provider):
+async def test_local_transcript_expiration(provider: LocalCacheProvider) -> None:
     data = {"text": "expiring"}
 
-    await provider.put_dict("transcript:hash123", data, 0.1)
+    await provider.put_dict("transcript:hash123", data, 1)
 
     assert await provider.get_dict("transcript:hash123") == data
 
-    await asyncio.sleep(0.2)
+    await asyncio.sleep(1.1)
 
     assert await provider.get_dict("transcript:hash123") is None

--- a/tests/cache/test_valkey.py
+++ b/tests/cache/test_valkey.py
@@ -2,9 +2,8 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from src.cache import ValkeyProvider
-from src.utils import compress, CompressionMethod
+from src.utils import CompressionMethod, compress
 
 
 @pytest.fixture

--- a/tests/cache/test_valkey.py
+++ b/tests/cache/test_valkey.py
@@ -7,17 +7,17 @@ from src.utils import CompressionMethod, compress
 
 
 @pytest.fixture
-def provider():
+def provider() -> ValkeyProvider:
     return ValkeyProvider("valkey://localhost:6379", compression_method="none")
 
 
 @pytest.fixture
-def provider_with_compression():
+def provider_with_compression() -> ValkeyProvider:
     return ValkeyProvider("valkey://localhost:6379", compression_method="gzip")
 
 
 @pytest.mark.asyncio
-async def test_valkey_rate_limit_success(provider):
+async def test_valkey_rate_limit_success(provider: ValkeyProvider) -> None:
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()
         mock_pipeline = MagicMock()
@@ -34,7 +34,7 @@ async def test_valkey_rate_limit_success(provider):
 
 
 @pytest.mark.asyncio
-async def test_valkey_rate_limit_exceeded(provider):
+async def test_valkey_rate_limit_exceeded(provider: ValkeyProvider) -> None:
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()
         mock_pipeline = MagicMock()
@@ -48,7 +48,7 @@ async def test_valkey_rate_limit_exceeded(provider):
 
 
 @pytest.mark.asyncio
-async def test_valkey_set_get_summary(provider):
+async def test_valkey_set_get_summary(provider: ValkeyProvider) -> None:
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()
         # With compression_method="none", data is stored with \x00 prefix
@@ -67,7 +67,7 @@ async def test_valkey_set_get_summary(provider):
 
 
 @pytest.mark.asyncio
-async def test_valkey_set_get_summary_with_compression(provider_with_compression):
+async def test_valkey_set_get_summary_with_compression(provider_with_compression: ValkeyProvider) -> None:
     """Test that summary is compressed when stored and decompressed when retrieved."""
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()
@@ -85,12 +85,12 @@ async def test_valkey_set_get_summary_with_compression(provider_with_compression
 
 
 @pytest.mark.asyncio
-async def test_valkey_set_get_summary_multiple_languages(provider):
+async def test_valkey_set_get_summary_multiple_languages(provider: ValkeyProvider) -> None:
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()
 
         # We will mock the .get() method to return different results based on the key
-        def mock_get(key):
+        def mock_get(key: str) -> bytes | None:
             if key == "summary:hash123:en:none":
                 return b"\x00english summary"
             elif key == "summary:hash123:es:none":
@@ -118,7 +118,7 @@ async def test_valkey_set_get_summary_multiple_languages(provider):
 
 
 @pytest.mark.asyncio
-async def test_valkey_set_get_transcript(provider):
+async def test_valkey_set_get_transcript(provider: ValkeyProvider) -> None:
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()
         transcript_json = '{"text": "hello"}'
@@ -137,7 +137,7 @@ async def test_valkey_set_get_transcript(provider):
 
 
 @pytest.mark.asyncio
-async def test_valkey_set_get_transcript_with_compression(provider_with_compression):
+async def test_valkey_set_get_transcript_with_compression(provider_with_compression: ValkeyProvider) -> None:
     """Test that transcript is compressed when stored and decompressed when retrieved."""
     with patch("src.cache.valkey.Valkey") as mock_valkey:
         mock_client = AsyncMock()

--- a/tests/cache/test_valkey.py
+++ b/tests/cache/test_valkey.py
@@ -1,9 +1,7 @@
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from valkey.exceptions import ConnectionError as ValkeyConnectionError
 
 from src.cache import ValkeyProvider
 from src.utils import compress, CompressionMethod

--- a/tests/load/test_video_loader.py
+++ b/tests/load/test_video_loader.py
@@ -54,312 +54,262 @@ def test_video_transcript_creation() -> None:
 
 
 def test_video_data_loader_initialization() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    settings = build_settings()
+    loader = VideoDataLoader(settings)
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
-
-        mock_build.assert_called_once_with("https://youtu.be/test")
-        assert loader.url == "https://www.youtube.com/watch?v=test"
-        assert loader.video_id == "test"
-        assert loader.info is None
-        assert loader.transcript is None
+    assert loader.settings == settings
+    assert loader.yt_dlp_additional_options == ()
 
 
 def test_video_data_loader_initialization_with_options() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(
+        build_settings(yt_dlp_additional_options=("--format", "mp4")),
+    )
 
-        loader = VideoDataLoader(
-            "https://youtu.be/test",
-            build_settings(yt_dlp_additional_options=("--format", "mp4")),
-        )
-
-        assert loader.yt_dlp_additional_options == ("--format", "mp4")
+    assert loader.yt_dlp_additional_options == ("--format", "mp4")
 
 
 def test_video_data_loader_subtitle_template_path() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
-        with patch("tempfile.gettempdir") as mock_temp:
-            mock_temp.return_value = "/tmp"
+    with patch("tempfile.gettempdir") as mock_temp:
+        mock_temp.return_value = "/tmp"
 
-            loader = VideoDataLoader("https://youtu.be/test", build_settings())
-            expected_path = "/tmp/subtitles_test.%(ext)s"
+        loader = VideoDataLoader(build_settings())
+        expected_path = "/tmp/subtitles_test.%(ext)s"
 
-            assert loader._subtitle_template_path == expected_path
+        assert loader._get_subtitle_template_path("test") == expected_path
 
 
 def test_video_data_loader_subtitle_prefix() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
-        with patch("tempfile.gettempdir") as mock_temp:
-            mock_temp.return_value = "/tmp"
+    with patch("tempfile.gettempdir") as mock_temp:
+        mock_temp.return_value = "/tmp"
 
-            loader = VideoDataLoader("https://youtu.be/test", build_settings())
-            expected_prefix = Path("/tmp/subtitles_test")
+        loader = VideoDataLoader(build_settings())
+        expected_prefix = Path("/tmp/subtitles_test")
 
-            assert loader._subtitle_prefix == expected_prefix
+        assert loader._get_subtitle_prefix("test") == expected_prefix
 
 
 def test_detect_language_with_video_info_language() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(build_settings())
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
+    info = VideoInfo(
+        id="test_id",
+        language="es-ES",  # Full language code with region
+        uploader="test_uploader",
+        title="test_title",
+        thumbnail="test_thumbnail",
+        subtitles={},
+    )
 
-        info = VideoInfo(
-            id="test_id",
-            language="es-ES",  # Full language code with region
-            uploader="test_uploader",
-            title="test_title",
-            thumbnail="test_thumbnail",
-            subtitles={},
-        )
-
-        # Should return base language without region
-        assert loader._detect_language(info) == "es"
+    # Should return base language without region
+    assert loader._detect_language(info) == "es"
 
 
 def test_detect_language_with_subtitles_en_priority() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(build_settings())
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
+    info = VideoInfo(
+        id="test_id",
+        language="",  # No language specified
+        uploader="test_uploader",
+        title="test_title",
+        thumbnail="test_thumbnail",
+        subtitles={"en": [], "es": []},  # English available
+    )
 
-        info = VideoInfo(
-            id="test_id",
-            language="",  # No language specified
-            uploader="test_uploader",
-            title="test_title",
-            thumbnail="test_thumbnail",
-            subtitles={"en": [], "es": []},  # English available
-        )
-
-        # Should prefer English when available
-        assert loader._detect_language(info) == "en"
+    # Should prefer English when available
+    assert loader._detect_language(info) == "en"
 
 
 def test_detect_language_with_subtitles_first_available() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(build_settings())
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
+    info = VideoInfo(
+        id="test_id",
+        language="",  # No language specified
+        uploader="test_uploader",
+        title="test_title",
+        thumbnail="test_thumbnail",
+        subtitles={"fr-FR": [], "de": []},  # No English available
+    )
 
-        info = VideoInfo(
-            id="test_id",
-            language="",  # No language specified
-            uploader="test_uploader",
-            title="test_title",
-            thumbnail="test_thumbnail",
-            subtitles={"fr-FR": [], "de": []},  # No English available
-        )
-
-        # Should return first available language (fr)
-        assert loader._detect_language(info) == "fr"
+    # Should return first available language (fr)
+    assert loader._detect_language(info) == "fr"
 
 
 def test_detect_language_no_subtitles_or_language() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(build_settings())
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
+    info = VideoInfo(
+        id="test_id",
+        language="",  # No language specified
+        uploader="test_uploader",
+        title="test_title",
+        thumbnail="test_thumbnail",
+        subtitles={},  # No subtitles available
+    )
 
-        info = VideoInfo(
-            id="test_id",
-            language="",  # No language specified
-            uploader="test_uploader",
-            title="test_title",
-            thumbnail="test_thumbnail",
-            subtitles={},  # No subtitles available
-        )
-
-        # Should raise RuntimeError when no subtitles available
-        with pytest.raises(RuntimeError, match="no subtitles available"):
-            loader._detect_language(info)
+    # Should raise RuntimeError when no subtitles available
+    with pytest.raises(RuntimeError, match="no subtitles available"):
+        loader._detect_language(info)
 
 
 def test_find_subtitle_file_exact_match() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
-        with patch("tempfile.gettempdir") as mock_temp:
-            mock_temp.return_value = "/tmp"
+    with patch("tempfile.gettempdir") as mock_temp:
+        mock_temp.return_value = "/tmp"
 
-            loader = VideoDataLoader("https://youtu.be/test", build_settings())
+        loader = VideoDataLoader(build_settings())
 
-            with patch("tempfile.gettempdir", return_value="/tmp"):
-                with patch.object(Path, "exists", return_value=True):
-                    result = loader._find_subtitle_file("en")
-                    expected_path = Path("/tmp") / "subtitles_test.en.srt"
-                    assert result == expected_path
+        with patch("tempfile.gettempdir", return_value="/tmp"):
+            with patch.object(Path, "exists", return_value=True):
+                result = loader._find_subtitle_file("test", "en")
+                expected_path = Path("/tmp") / "subtitles_test.en.srt"
+                assert result == expected_path
 
 
 def test_build_ydl_opts_base_options() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(build_settings())
+    opts = loader._build_ydl_opts()
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
-        opts = loader._build_ydl_opts()
-
-        assert opts["quiet"] is True
-        assert opts["no_warnings"] is True
-        assert opts["extract_flat"] is False
+    assert opts["quiet"] is True
+    assert opts["no_warnings"] is True
+    assert opts["extract_flat"] is False
 
 
 def test_build_ydl_opts_with_extra_options() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(build_settings())
+    opts = loader._build_ydl_opts({"dumpjson": True, "skip_download": True})
 
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
-        opts = loader._build_ydl_opts({"dumpjson": True, "skip_download": True})
-
-        assert opts["dumpjson"] is True
-        assert opts["skip_download"] is True
+    assert opts["dumpjson"] is True
+    assert opts["skip_download"] is True
 
 
 def test_build_ydl_opts_with_user_options() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    loader = VideoDataLoader(
+        build_settings(yt_dlp_additional_options=("--format", "mp4", "--cookies", "cookies.txt")),
+    )
+    opts = loader._build_ydl_opts()
 
-        loader = VideoDataLoader(
-            "https://youtu.be/test",
-            build_settings(yt_dlp_additional_options=("--format", "mp4", "--cookies", "cookies.txt")),
-        )
-        opts = loader._build_ydl_opts()
-
-        assert opts["format"] == "mp4"
-        assert opts["cookies"] == "cookies.txt"
+    assert opts["format"] == "mp4"
+    assert opts["cookies"] == "cookies.txt"
 
 
 @patch("yt_dlp.YoutubeDL")
 def test_load_success(mock_youtube_dl_class: MagicMock) -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    # Mock the context manager
+    mock_ydl = MagicMock()
+    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+    mock_ydl.__exit__ = MagicMock(return_value=False)
+    mock_youtube_dl_class.return_value = mock_ydl
 
-        # Mock the context manager
-        mock_ydl = MagicMock()
-        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
-        mock_ydl.__exit__ = MagicMock(return_value=False)
-        mock_youtube_dl_class.return_value = mock_ydl
+    # First call: extract_info for video info
+    # Second call: extract_info for subtitles
+    mock_ydl.extract_info.side_effect = [
+        {
+            "id": "test_id",
+            "language": "en",
+            "uploader": "test_uploader",
+            "title": "test_title",
+            "thumbnail": "test_thumbnail",
+            "subtitles": {"en": []},
+        },
+        None,  # Download returns None
+    ]
 
-        # First call: extract_info for video info
-        # Second call: extract_info for subtitles
-        mock_ydl.extract_info.side_effect = [
-            {
-                "id": "test_id",
-                "language": "en",
-                "uploader": "test_uploader",
-                "title": "test_title",
-                "thumbnail": "test_thumbnail",
-                "subtitles": {"en": []},
-            },
-            None,  # Download returns None
-        ]
+    # Mock subtitle file
+    mock_subtitle_file = MagicMock()
+    mock_subtitle_file.read_text.return_value = "1\n00:00:00,000 --> 00:00:01,000\nTest subtitle"
+    mock_subtitle_file.exists.return_value = True
 
-        # Mock subtitle file
-        mock_subtitle_file = MagicMock()
-        mock_subtitle_file.read_text.return_value = "1\n00:00:00,000 --> 00:00:01,000\nTest subtitle"
-        mock_subtitle_file.exists.return_value = True
+    with patch.object(VideoDataLoader, "_find_subtitle_file", return_value=mock_subtitle_file):
+        with patch("src.load.video_loader.clean_srt", return_value="Test subtitle"):
+            loader = VideoDataLoader(build_settings())
+            transcript = loader._load("https://youtu.be/test", "test")
 
-        with patch.object(VideoDataLoader, "_find_subtitle_file", return_value=mock_subtitle_file):
-            with patch("src.load.video_loader.clean_srt", return_value="Test subtitle"):
-                loader = VideoDataLoader("https://youtu.be/test", build_settings())
-                loader._load()
-
-                assert loader.info is not None
-                assert loader.info.id == "test_id"
-                assert loader.transcript is not None
-                assert loader.transcript.transcript == "Test subtitle"
+            assert transcript is not None
+            assert transcript.id == "test_id"
+            assert transcript.transcript == "Test subtitle"
 
 
 @patch("yt_dlp.YoutubeDL")
 def test_load_retry_on_info_failure(mock_youtube_dl_class: MagicMock) -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    # Mock the context manager
+    mock_ydl = MagicMock()
+    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+    mock_ydl.__exit__ = MagicMock(return_value=False)
+    mock_youtube_dl_class.return_value = mock_ydl
 
-        # Mock the context manager
-        mock_ydl = MagicMock()
-        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
-        mock_ydl.__exit__ = MagicMock(return_value=False)
-        mock_youtube_dl_class.return_value = mock_ydl
+    # Fail twice, succeed on third
+    mock_ydl.extract_info.side_effect = [
+        Exception("Network error"),
+        Exception("Network error"),
+        {
+            "id": "test_id",
+            "language": "en",
+            "uploader": "test_uploader",
+            "title": "test_title",
+            "thumbnail": "test_thumbnail",
+            "subtitles": {"en": []},
+        },
+        None,  # Download returns None
+    ]
 
-        # Fail twice, succeed on third
-        mock_ydl.extract_info.side_effect = [
-            Exception("Network error"),
-            Exception("Network error"),
-            {
-                "id": "test_id",
-                "language": "en",
-                "uploader": "test_uploader",
-                "title": "test_title",
-                "thumbnail": "test_thumbnail",
-                "subtitles": {"en": []},
-            },
-            None,  # Download returns None
-        ]
+    # Mock subtitle file
+    mock_subtitle_file = MagicMock()
+    mock_subtitle_file.read_text.return_value = "1\n00:00:00,000 --> 00:00:01,000\nTest subtitle"
+    mock_subtitle_file.exists.return_value = True
 
-        # Mock subtitle file
-        mock_subtitle_file = MagicMock()
-        mock_subtitle_file.read_text.return_value = "1\n00:00:00,000 --> 00:00:01,000\nTest subtitle"
-        mock_subtitle_file.exists.return_value = True
+    with patch.object(VideoDataLoader, "_find_subtitle_file", return_value=mock_subtitle_file):
+        with patch("src.load.video_loader.clean_srt", return_value="Test subtitle"):
+            loader = VideoDataLoader(build_settings())
+            loader._load("https://youtu.be/test", "test")
 
-        with patch.object(VideoDataLoader, "_find_subtitle_file", return_value=mock_subtitle_file):
-            with patch("src.load.video_loader.clean_srt", return_value="Test subtitle"):
-                loader = VideoDataLoader("https://youtu.be/test", build_settings())
-                loader._load()
-
-                # Should have been called 4 times (2 info failures + 1 info success + 1 subtitle download)
-                expected_calls = 4
-                assert mock_ydl.extract_info.call_count == expected_calls
+            # Should have been called 4 times (2 info failures + 1 info success + 1 subtitle download)
+            expected_calls = 4
+            assert mock_ydl.extract_info.call_count == expected_calls
 
 
 @patch("yt_dlp.YoutubeDL")
 def test_load_failure_all_attempts(mock_youtube_dl_class: MagicMock) -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    # Mock the context manager
+    mock_ydl = MagicMock()
+    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+    mock_ydl.__exit__ = MagicMock(return_value=False)
+    mock_youtube_dl_class.return_value = mock_ydl
 
-        # Mock the context manager
-        mock_ydl = MagicMock()
-        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
-        mock_ydl.__exit__ = MagicMock(return_value=False)
-        mock_youtube_dl_class.return_value = mock_ydl
+    # Always fail
+    mock_ydl.extract_info.side_effect = Exception("Network error")
 
-        # Always fail
-        mock_ydl.extract_info.side_effect = Exception("Network error")
-
-        loader = VideoDataLoader("https://youtu.be/test", build_settings())
-        with pytest.raises(RuntimeError, match="Failed to load video info after 3 attempts"):
-            loader._load()
+    loader = VideoDataLoader(build_settings())
+    with pytest.raises(RuntimeError, match="Failed to load video info after 3 attempts"):
+        loader._load("https://youtu.be/test", "test")
 
 
 @patch("yt_dlp.YoutubeDL")
 def test_load_no_subtitles_found(mock_youtube_dl_class: MagicMock) -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    # Mock the context manager
+    mock_ydl = MagicMock()
+    mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+    mock_ydl.__exit__ = MagicMock(return_value=False)
+    mock_youtube_dl_class.return_value = mock_ydl
 
-        # Mock the context manager
-        mock_ydl = MagicMock()
-        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
-        mock_ydl.__exit__ = MagicMock(return_value=False)
-        mock_youtube_dl_class.return_value = mock_ydl
+    # Info succeeds, download succeeds but no file found
+    mock_ydl.extract_info.side_effect = [
+        {
+            "id": "test_id",
+            "language": "en",
+            "uploader": "test_uploader",
+            "title": "test_title",
+            "thumbnail": "test_thumbnail",
+            "subtitles": {"en": []},
+        },
+        None,
+    ]
 
-        # Info succeeds, download succeeds but no file found
-        mock_ydl.extract_info.side_effect = [
-            {
-                "id": "test_id",
-                "language": "en",
-                "uploader": "test_uploader",
-                "title": "test_title",
-                "thumbnail": "test_thumbnail",
-                "subtitles": {"en": []},
-            },
-            None,
-        ]
-
-        with patch.object(VideoDataLoader, "_find_subtitle_file", return_value=None):
-            loader = VideoDataLoader("https://youtu.be/test", build_settings())
-            with pytest.raises(FileNotFoundError, match="no subtitles found"):
-                loader._load()
+    with patch.object(VideoDataLoader, "_find_subtitle_file", return_value=None):
+        loader = VideoDataLoader(build_settings())
+        with pytest.raises(FileNotFoundError, match="no subtitles found"):
+            loader._load("https://youtu.be/test", "test")
 
 
 def test_is_safe_option_value() -> None:
@@ -381,14 +331,11 @@ def test_is_safe_option_value() -> None:
 
 
 def test_ydl_opts_filters_unsafe_values() -> None:
-    with patch("src.load.video_loader.build_video_source") as mock_build:
-        mock_build.return_value = ("https://www.youtube.com/watch?v=test", "test")
+    # Include an unsafe option value
+    unsafe_settings = build_settings(yt_dlp_additional_options=("--format", "mp4", "--outtmpl", "/etc/passwd"))
+    loader = VideoDataLoader(unsafe_settings)
+    opts = loader._build_ydl_opts()
 
-        # Include an unsafe option value
-        unsafe_settings = build_settings(yt_dlp_additional_options=("--format", "mp4", "--outtmpl", "/etc/passwd"))
-        loader = VideoDataLoader("https://youtu.be/test", unsafe_settings)
-        opts = loader._build_ydl_opts()
-
-        # The safe format should be included, but the unsafe outtmpl should be omitted
-        assert opts.get("format") == "mp4"
-        assert "outtmpl" not in opts
+    # The safe format should be included, but the unsafe outtmpl should be omitted
+    assert opts.get("format") == "mp4"
+    assert "outtmpl" not in opts

--- a/tests/load/test_video_loader.py
+++ b/tests/load/test_video_loader.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch, MagicMock
 from pathlib import Path
-from src.load.video_loader import VideoDataLoader, VideoInfo, VideoTranscript
+from unittest.mock import MagicMock, patch
+
 from src.config import Settings
+from src.load.video_loader import VideoDataLoader, VideoInfo, VideoTranscript
 
 
 def build_settings(**overrides: object) -> Settings:

--- a/tests/load/test_video_provider.py
+++ b/tests/load/test_video_provider.py
@@ -1,10 +1,10 @@
 from src.load.video_provider import (
-    build_video_source,
-    extract_urls,
+    PROVIDERS,
+    VKVIDEO,
     YOUTUBE,
     YOUTUBE_SHORT,
-    VKVIDEO,
-    PROVIDERS,
+    build_video_source,
+    extract_urls,
 )
 
 

--- a/tests/load/test_video_provider.py
+++ b/tests/load/test_video_provider.py
@@ -1,3 +1,4 @@
+import pytest
 from src.load.video_provider import (
     PROVIDERS,
     VKVIDEO,
@@ -101,11 +102,8 @@ def test_build_video_source_vkvideo() -> None:
 
 
 def test_build_video_source_invalid_url() -> None:
-    try:
+    with pytest.raises(ValueError, match="no valid URL found"):
         build_video_source("https://invalid.com/video")
-        assert False, "Expected ValueError for invalid URL"
-    except ValueError as e:
-        assert "no valid URL found" in str(e)
 
 
 def test_youtube_provider_is_valid_url() -> None:
@@ -141,7 +139,8 @@ def test_vkvideo_provider_get_id() -> None:
 
 
 def test_all_providers_defined() -> None:
-    assert len(PROVIDERS) == 3
+    expected_provider_count = 3
+    assert len(PROVIDERS) == expected_provider_count
     assert YOUTUBE in PROVIDERS
     assert YOUTUBE_SHORT in PROVIDERS
     assert VKVIDEO in PROVIDERS

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -143,7 +143,7 @@ async def test_bot_handle_message_no_text(bot: TelegramBrieflyBot, mock_update: 
         patch.object(bot.rate_limiter, "is_limited", return_value=False),
         patch("src.bot.translate", return_value="No URL"),
     ):
-        await bot._handle_message(mock_update, mock_context)
+        await bot._process_message(mock_update, mock_context)
     mock_update.effective_message.reply_text.assert_called_once()
     assert mock_update.effective_message.reply_text.call_args[0][0] == "No URL"
 
@@ -154,7 +154,7 @@ async def test_bot_handle_message_rate_limited(bot: TelegramBrieflyBot, mock_upd
         patch.object(bot.rate_limiter, "is_limited", return_value=True),
         patch("src.bot.translate", return_value="Rate Limited"),
     ):
-        await bot._handle_message(mock_update, mock_context)
+        await bot._process_message(mock_update, mock_context)
     mock_update.effective_message.reply_text.assert_called_once_with("Rate Limited", message_thread_id=None, reply_to_message_id=1)
 
 
@@ -168,7 +168,7 @@ async def test_bot_handle_message_multiple_urls(bot: TelegramBrieflyBot, mock_up
     ):
         processing_msg_mock = AsyncMock()
         mock_update.effective_message.reply_text.return_value = processing_msg_mock
-        await bot._handle_message(mock_update, mock_context)
+        await bot._process_message(mock_update, mock_context)
         processing_msg_mock.edit_text.assert_called_once_with("Error")
 
 
@@ -186,7 +186,7 @@ async def test_bot_handle_message_success(bot: TelegramBrieflyBot, mock_update: 
         patch.object(bot.summarizer, "summarize", return_value="Test summary") as mock_summarize,
         patch("src.bot.translate", side_effect=lambda key, **kw: key),
     ):
-        await bot._handle_message(mock_update, mock_context)
+        await bot._process_message(mock_update, mock_context)
 
         mock_load.assert_called_once_with("https://youtube.com/watch?v=123")
         mock_summarize.assert_called_once_with("Test transcript", "en")
@@ -208,7 +208,7 @@ async def test_bot_handle_message_loader_fails(bot: TelegramBrieflyBot, mock_upd
         patch.object(bot.loader, "load", side_effect=Exception("Load error")),
         patch("src.bot.translate", return_value="Fail"),
     ):
-        await bot._handle_message(mock_update, mock_context)
+        await bot._process_message(mock_update, mock_context)
         processing_msg_mock.edit_text.assert_called_with("Fail")
 
 
@@ -225,7 +225,7 @@ async def test_bot_handle_message_summarizer_fails(bot: TelegramBrieflyBot, mock
         patch.object(bot.summarizer, "summarize", side_effect=Exception("Summarize error")),
         patch("src.bot.translate", return_value="Fail"),
     ):
-        await bot._handle_message(mock_update, mock_context)
+        await bot._process_message(mock_update, mock_context)
         processing_msg_mock.edit_text.assert_called_with("Fail")
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,10 +2,9 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from src.bot import TelegramBrieflyBot
-from src.config import Settings
 from src.cache import LocalCacheProvider
+from src.config import Settings
 from src.rate_limiter import UserRateLimiter
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,9 +1,12 @@
-import pytest
-from unittest.mock import MagicMock, patch
 import asyncio
-from src.bot import UserRateLimiter, TelegramBrieflyBot
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.bot import TelegramBrieflyBot
 from src.config import Settings
 from src.cache import LocalCacheProvider
+from src.rate_limiter import UserRateLimiter
 
 
 @pytest.mark.asyncio
@@ -58,6 +61,8 @@ def test_telegram_briefly_bot_initialization() -> None:
     mock_settings.openai_base_url = "https://api.openai.com/v1/"
     mock_settings.openai_api_key = "test_key"
     mock_settings.openai_model = "gpt-3.5-turbo"
+    mock_settings.valkey_url = None
+    mock_settings.cache_compression_method = "gzip"
 
     with patch("src.bot.OpenAISummarizer") as mock_summarizer_class:
         mock_summarizer_instance = MagicMock()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -135,9 +135,7 @@ async def test_bot_start(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_c
 
 
 @pytest.mark.asyncio
-async def test_bot_handle_message_no_text(
-    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
-) -> None:
+async def test_bot_handle_message_no_text(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
     mock_update.effective_message.text = None
     with (
         patch.object(bot.rate_limiter, "is_limited", return_value=False),
@@ -149,23 +147,17 @@ async def test_bot_handle_message_no_text(
 
 
 @pytest.mark.asyncio
-async def test_bot_handle_message_rate_limited(
-    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
-) -> None:
+async def test_bot_handle_message_rate_limited(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
     with (
         patch.object(bot.rate_limiter, "is_limited", return_value=True),
         patch("src.bot.translate", return_value="Rate Limited"),
     ):
         await bot._handle_message(mock_update, mock_context)
-    mock_update.effective_message.reply_text.assert_called_once_with(
-        "Rate Limited", message_thread_id=None, reply_to_message_id=1
-    )
+    mock_update.effective_message.reply_text.assert_called_once_with("Rate Limited", message_thread_id=None, reply_to_message_id=1)
 
 
 @pytest.mark.asyncio
-async def test_bot_handle_message_multiple_urls(
-    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
-) -> None:
+async def test_bot_handle_message_multiple_urls(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
     mock_update.effective_message.text = "url1.com url2.com"
     with (
         patch.object(bot.rate_limiter, "is_limited", return_value=False),
@@ -179,12 +171,8 @@ async def test_bot_handle_message_multiple_urls(
 
 
 @pytest.mark.asyncio
-async def test_bot_handle_message_success(
-    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
-) -> None:
-    transcript = VideoTranscript(
-        id="123", language="en", uploader="test", title="Test Video", thumbnail="", transcript="Test transcript"
-    )
+async def test_bot_handle_message_success(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
+    transcript = VideoTranscript(id="123", language="en", uploader="test", title="Test Video", thumbnail="", transcript="Test transcript")
 
     processing_msg_mock = AsyncMock()
     mock_update.effective_message.reply_text.return_value = processing_msg_mock
@@ -213,9 +201,7 @@ async def test_bot_handle_message_success(
 
 
 @pytest.mark.asyncio
-async def test_bot_handle_message_loader_fails(
-    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
-) -> None:
+async def test_bot_handle_message_loader_fails(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
     processing_msg_mock = AsyncMock()
     mock_update.effective_message.reply_text.return_value = processing_msg_mock
 
@@ -234,12 +220,8 @@ async def test_bot_handle_message_loader_fails(
 
 
 @pytest.mark.asyncio
-async def test_bot_handle_message_summarizer_fails(
-    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
-) -> None:
-    transcript = VideoTranscript(
-        id="123", language="en", uploader="test", title="Test Video", thumbnail="", transcript="Test transcript"
-    )
+async def test_bot_handle_message_summarizer_fails(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
+    transcript = VideoTranscript(id="123", language="en", uploader="test", title="Test Video", thumbnail="", transcript="Test transcript")
     processing_msg_mock = AsyncMock()
     mock_update.effective_message.reply_text.return_value = processing_msg_mock
 
@@ -263,6 +245,4 @@ async def test_bot_on_error(bot: TelegramBrieflyBot, mock_update: MagicMock, moc
     mock_context.error = Exception("General error")
     with patch("src.bot.translate", return_value="Error handled"):
         await bot._on_error(mock_update, mock_context)
-    mock_update.effective_message.reply_text.assert_called_once_with(
-        "Error handled", message_thread_id=None, reply_to_message_id=1
-    )
+    mock_update.effective_message.reply_text.assert_called_once_with("Error handled", message_thread_id=None, reply_to_message_id=1)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,11 +1,14 @@
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from src.bot import TelegramBrieflyBot
 from src.cache import LocalCacheProvider
 from src.config import Settings
+from src.load.video_loader import VideoTranscript
 from src.rate_limiter import UserRateLimiter
+from telegram import Message, Update, User
+from telegram.ext import ContextTypes
 
 
 @pytest.mark.asyncio
@@ -35,7 +38,7 @@ async def test_user_rate_limiter_different_users() -> None:
 
 @pytest.mark.asyncio
 async def test_user_rate_limiter_after_cooldown() -> None:
-    limiter = UserRateLimiter(provider=LocalCacheProvider(), cooldown_seconds=0.1)  # Short cooldown for testing
+    limiter = UserRateLimiter(provider=LocalCacheProvider(), cooldown_seconds=1)  # Short cooldown for testing
 
     # First request
     is_limited = await limiter.is_limited(123)
@@ -46,7 +49,7 @@ async def test_user_rate_limiter_after_cooldown() -> None:
     assert is_limited is True
 
     # Wait for cooldown period
-    await asyncio.sleep(0.2)
+    await asyncio.sleep(1.1)
 
     # Third request after cooldown should not be limited
     is_limited = await limiter.is_limited(123)
@@ -71,6 +74,195 @@ def test_telegram_briefly_bot_initialization() -> None:
 
         # Verify initialization
         assert bot.settings == mock_settings
-        assert bot.rate_limiter.cooldown_seconds == 10
+        expected_cooldown = 10
+        assert bot.rate_limiter.cooldown_seconds == expected_cooldown
         # Verify OpenAISummarizer was initialized with settings
         mock_summarizer_class.assert_called_once_with(mock_settings)
+
+
+@pytest.fixture
+def mock_settings() -> Settings:
+    settings = MagicMock(spec=Settings)
+    settings.rate_limit_window_seconds = 10
+    settings.telegram_bot_token = "test_token"
+    settings.openai_base_url = "https://api.openai.com/v1/"
+    settings.openai_api_key = "test_key"
+    settings.openai_model = "gpt-3.5-turbo"
+    settings.valkey_url = None
+    settings.cache_compression_method = "gzip"
+    settings.max_telegram_message_length = 4000
+    return settings
+
+
+@pytest.fixture
+def bot(mock_settings: Settings) -> TelegramBrieflyBot:
+    with patch("src.bot.ApplicationBuilder"):
+        return TelegramBrieflyBot(mock_settings)
+
+
+@pytest.fixture
+def mock_update() -> MagicMock:
+    update = MagicMock(spec=Update)
+    user = MagicMock(spec=User)
+    user.id = 123
+    user.username = "testuser"
+    user.language_code = "en"
+    user.is_bot = False
+    update.effective_user = user
+
+    message = AsyncMock(spec=Message)
+    message.message_id = 1
+    message.id = 1
+    message.message_thread_id = None
+    message.text = "https://youtube.com/watch?v=123"
+    message.reply_text = AsyncMock()
+    update.effective_message = message
+
+    return update
+
+
+@pytest.fixture
+def mock_context() -> MagicMock:
+    return MagicMock(spec=ContextTypes.DEFAULT_TYPE)
+
+
+@pytest.mark.asyncio
+async def test_bot_start(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
+    # Need to mock translate since we aren't loading translations in unit tests by default
+    with patch("src.bot.translate", return_value="Welcome"):
+        await bot._start(mock_update, mock_context)
+    mock_update.effective_message.reply_text.assert_called_once_with("Welcome")
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_message_no_text(
+    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
+) -> None:
+    mock_update.effective_message.text = None
+    with (
+        patch.object(bot.rate_limiter, "is_limited", return_value=False),
+        patch("src.bot.translate", return_value="No URL"),
+    ):
+        await bot._handle_message(mock_update, mock_context)
+    mock_update.effective_message.reply_text.assert_called_once()
+    assert mock_update.effective_message.reply_text.call_args[0][0] == "No URL"
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_message_rate_limited(
+    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
+) -> None:
+    with (
+        patch.object(bot.rate_limiter, "is_limited", return_value=True),
+        patch("src.bot.translate", return_value="Rate Limited"),
+    ):
+        await bot._handle_message(mock_update, mock_context)
+    mock_update.effective_message.reply_text.assert_called_once_with(
+        "Rate Limited", message_thread_id=None, reply_to_message_id=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_message_multiple_urls(
+    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
+) -> None:
+    mock_update.effective_message.text = "url1.com url2.com"
+    with (
+        patch.object(bot.rate_limiter, "is_limited", return_value=False),
+        patch("src.bot.extract_urls", return_value=["url1", "url2"]),
+        patch("src.bot.translate", return_value="Error"),
+    ):
+        processing_msg_mock = AsyncMock()
+        mock_update.effective_message.reply_text.return_value = processing_msg_mock
+        await bot._handle_message(mock_update, mock_context)
+        processing_msg_mock.edit_text.assert_called_once_with("Error")
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_message_success(
+    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
+) -> None:
+    transcript = VideoTranscript(
+        id="123", language="en", uploader="test", title="Test Video", thumbnail="", transcript="Test transcript"
+    )
+
+    processing_msg_mock = AsyncMock()
+    mock_update.effective_message.reply_text.return_value = processing_msg_mock
+
+    with (
+        patch.object(bot.rate_limiter, "is_limited", return_value=False),
+        patch("src.bot.extract_urls", return_value=["https://youtube.com/watch?v=123"]),
+        patch("src.bot.VideoDataLoader") as mock_loader_class,
+        patch.object(bot.summarizer, "summarize", return_value="Test summary") as mock_summarize,
+        patch("src.bot.translate", side_effect=lambda key, **kw: key),
+    ):
+        mock_loader_instance = AsyncMock()
+        mock_loader_instance.load.return_value = transcript
+        mock_loader_class.return_value = mock_loader_instance
+
+        await bot._handle_message(mock_update, mock_context)
+
+        mock_loader_class.assert_called_once()
+        mock_loader_instance.load.assert_called_once()
+        mock_summarize.assert_called_once_with("Test transcript", "en")
+
+        # Original message reply for processing, and second reply for final result
+        expected_calls = 2
+        assert mock_update.effective_message.reply_text.call_count == expected_calls
+        processing_msg_mock.delete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_message_loader_fails(
+    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
+) -> None:
+    processing_msg_mock = AsyncMock()
+    mock_update.effective_message.reply_text.return_value = processing_msg_mock
+
+    with (
+        patch.object(bot.rate_limiter, "is_limited", return_value=False),
+        patch("src.bot.extract_urls", return_value=["https://youtube.com/watch?v=123"]),
+        patch("src.bot.VideoDataLoader") as mock_loader_class,
+        patch("src.bot.translate", return_value="Fail"),
+    ):
+        mock_loader_instance = AsyncMock()
+        mock_loader_instance.load.side_effect = Exception("Load error")
+        mock_loader_class.return_value = mock_loader_instance
+
+        await bot._handle_message(mock_update, mock_context)
+        processing_msg_mock.edit_text.assert_called_with("Fail")
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_message_summarizer_fails(
+    bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock
+) -> None:
+    transcript = VideoTranscript(
+        id="123", language="en", uploader="test", title="Test Video", thumbnail="", transcript="Test transcript"
+    )
+    processing_msg_mock = AsyncMock()
+    mock_update.effective_message.reply_text.return_value = processing_msg_mock
+
+    with (
+        patch.object(bot.rate_limiter, "is_limited", return_value=False),
+        patch("src.bot.extract_urls", return_value=["https://youtube.com/watch?v=123"]),
+        patch("src.bot.VideoDataLoader") as mock_loader_class,
+        patch.object(bot.summarizer, "summarize", side_effect=Exception("Summarize error")),
+        patch("src.bot.translate", return_value="Fail"),
+    ):
+        mock_loader_instance = AsyncMock()
+        mock_loader_instance.load.return_value = transcript
+        mock_loader_class.return_value = mock_loader_instance
+
+        await bot._handle_message(mock_update, mock_context)
+        processing_msg_mock.edit_text.assert_called_with("Fail")
+
+
+@pytest.mark.asyncio
+async def test_bot_on_error(bot: TelegramBrieflyBot, mock_update: MagicMock, mock_context: MagicMock) -> None:
+    mock_context.error = Exception("General error")
+    with patch("src.bot.translate", return_value="Error handled"):
+        await bot._on_error(mock_update, mock_context)
+    mock_update.effective_message.reply_text.assert_called_once_with(
+        "Error handled", message_thread_id=None, reply_to_message_id=1
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
-from unittest.mock import patch
 import os
+from unittest.mock import patch
+
 from src.config import Settings
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
+import dataclasses
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
 from src.config import Settings
 
 
@@ -30,18 +32,15 @@ def test_settings_from_env_success() -> None:
 
 
 @patch("src.config.load_dotenv")
-def test_settings_from_env_missing_required_variables(mock_load_dotenv) -> None:
+def test_settings_from_env_missing_required_variables(mock_load_dotenv: MagicMock) -> None:
     # Test with missing TELEGRAM_BOT_TOKEN
     with patch.dict(
         os.environ,
         {"OPENAI_API_KEY": "test_api_key", "OPENAI_MODEL": "gpt-3.5-turbo"},
         clear=True,
     ):
-        try:
+        with pytest.raises(RuntimeError, match="TELEGRAM_BOT_TOKEN"):
             Settings.from_env()
-            assert False, "Expected RuntimeError for missing env vars"
-        except RuntimeError as e:
-            assert "TELEGRAM_BOT_TOKEN" in str(e)
 
     # Test with missing OPENAI_API_KEY
     with patch.dict(
@@ -49,11 +48,8 @@ def test_settings_from_env_missing_required_variables(mock_load_dotenv) -> None:
         {"TELEGRAM_BOT_TOKEN": "test_token", "OPENAI_MODEL": "gpt-3.5-turbo"},
         clear=True,
     ):
-        try:
+        with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
             Settings.from_env()
-            assert False, "Expected RuntimeError for missing env vars"
-        except RuntimeError as e:
-            assert "OPENAI_API_KEY" in str(e)
 
     # Test with missing OPENAI_MODEL
     with patch.dict(
@@ -61,15 +57,12 @@ def test_settings_from_env_missing_required_variables(mock_load_dotenv) -> None:
         {"TELEGRAM_BOT_TOKEN": "test_token", "OPENAI_API_KEY": "test_api_key"},
         clear=True,
     ):
-        try:
+        with pytest.raises(RuntimeError, match="OPENAI_MODEL"):
             Settings.from_env()
-            assert False, "Expected RuntimeError for missing env vars"
-        except RuntimeError as e:
-            assert "OPENAI_MODEL" in str(e)
 
 
 @patch("src.config.load_dotenv")
-def test_settings_from_env_default_values(mock_load_dotenv) -> None:
+def test_settings_from_env_default_values(mock_load_dotenv: MagicMock) -> None:
     with patch.dict(
         os.environ,
         {
@@ -81,12 +74,16 @@ def test_settings_from_env_default_values(mock_load_dotenv) -> None:
     ):
         settings = Settings.from_env()
 
+        expected_rate_limit = 10
+        expected_msg_len = 3500
+        expected_timeout = 300
+        expected_retries = 3
         # Check default values
         assert settings.openai_base_url == "https://api.openai.com/v1/"  # Default from code
-        assert settings.rate_limit_window_seconds == 10
-        assert settings.max_telegram_message_length == 3500
-        assert settings.openai_timeout_seconds == 300
-        assert settings.openai_max_retries == 3
+        assert settings.rate_limit_window_seconds == expected_rate_limit
+        assert settings.max_telegram_message_length == expected_msg_len
+        assert settings.openai_timeout_seconds == expected_timeout
+        assert settings.openai_max_retries == expected_retries
         assert settings.yt_dlp_additional_options == ()
 
 
@@ -129,9 +126,5 @@ def test_settings_immutability() -> None:
         settings = Settings.from_env()
 
         # Attempt to modify should raise an exception since it's a frozen dataclass
-        try:
-            settings.telegram_bot_token = "new_token"
-            assert False, "Expected dataclass.FrozenInstanceError"
-        except Exception:
-            # Expected behavior - frozen dataclass can't be modified
-            pass
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            settings.telegram_bot_token = "new_token"  # type: ignore[misc]

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -48,7 +48,8 @@ def test_setup_i18n_called_once() -> None:
 
         # Check that the setup methods were called only once
         assert mock_i18n.load_path.append.called
-        assert mock_i18n.set.call_count == 6  # Exactly 6 set calls
+        expected_set_calls = 6
+        assert mock_i18n.set.call_count == expected_set_calls  # Exactly 6 set calls
 
 
 def test_translate_basic() -> None:
@@ -83,7 +84,8 @@ def test_translate_fallback_to_default_locale() -> None:
 
         # Should try the requested locale first, then fall back to default
         assert result == "Fallback translation"
-        assert mock_i18n.t.call_count == 2
+        expected_t_calls = 2
+        assert mock_i18n.t.call_count == expected_t_calls
 
 
 def test_translate_returns_key_if_not_found() -> None:

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
-from src.localization import translate, normalize_locale, _setup_i18n, DEFAULT_LOCALE
+
+from src.localization import DEFAULT_LOCALE, _setup_i18n, normalize_locale, translate
 
 
 def testnormalize_locale_none() -> None:

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -1,41 +1,41 @@
 from unittest.mock import patch
-from src.localization import translate, _normalize_locale, _setup_i18n, DEFAULT_LOCALE
+from src.localization import translate, normalize_locale, _setup_i18n, DEFAULT_LOCALE
 
 
-def test_normalize_locale_none() -> None:
-    assert _normalize_locale(None) == DEFAULT_LOCALE
+def testnormalize_locale_none() -> None:
+    assert normalize_locale(None) == DEFAULT_LOCALE
 
 
-def test_normalize_locale_empty() -> None:
-    assert _normalize_locale("") == DEFAULT_LOCALE
+def testnormalize_locale_empty() -> None:
+    assert normalize_locale("") == DEFAULT_LOCALE
 
 
-def test_normalize_locale_basic() -> None:
-    assert _normalize_locale("en") == "en"
-    assert _normalize_locale("fr") == "fr"
+def testnormalize_locale_basic() -> None:
+    assert normalize_locale("en") == "en"
+    assert normalize_locale("fr") == "fr"
 
 
-def test_normalize_locale_with_underscores() -> None:
-    assert _normalize_locale("en_US") == "en"
-    assert _normalize_locale("fr_FR") == "fr"
-    assert _normalize_locale("de_DE") == "de"
+def testnormalize_locale_with_underscores() -> None:
+    assert normalize_locale("en_US") == "en"
+    assert normalize_locale("fr_FR") == "fr"
+    assert normalize_locale("de_DE") == "de"
 
 
-def test_normalize_locale_with_hyphens() -> None:
-    assert _normalize_locale("en-US") == "en"
-    assert _normalize_locale("fr-FR") == "fr"
-    assert _normalize_locale("pt-BR") == "pt"
+def testnormalize_locale_with_hyphens() -> None:
+    assert normalize_locale("en-US") == "en"
+    assert normalize_locale("fr-FR") == "fr"
+    assert normalize_locale("pt-BR") == "pt"
 
 
-def test_normalize_locale_case_insensitive() -> None:
-    assert _normalize_locale("EN") == "en"
-    assert _normalize_locale("Fr") == "fr"
-    assert _normalize_locale("ZH-CN") == "zh"
+def testnormalize_locale_case_insensitive() -> None:
+    assert normalize_locale("EN") == "en"
+    assert normalize_locale("Fr") == "fr"
+    assert normalize_locale("ZH-CN") == "zh"
 
 
-def test_normalize_locale_with_extra_spaces() -> None:
-    assert _normalize_locale(" en ") == "en"
-    assert _normalize_locale(" fr-FR ") == "fr"
+def testnormalize_locale_with_extra_spaces() -> None:
+    assert normalize_locale(" en ") == "en"
+    assert normalize_locale(" fr-FR ") == "fr"
 
 
 def test_setup_i18n_called_once() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
-from unittest.mock import patch, MagicMock
-import os
 import logging
+import os
+from unittest.mock import MagicMock, patch
+
 from src.main import configure_logging, main
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,8 @@ import logging
 import os
 from unittest.mock import MagicMock, patch
 
-from src.main import configure_logging, main
+from src.logger import configure_logging
+from src.main import main
 
 
 def test_configure_logging_default() -> None:
@@ -18,7 +19,7 @@ def test_configure_logging_default() -> None:
         mock_handler = MagicMock()
 
         # Return different loggers based on name
-        def get_logger_side_effect(name=None):
+        def get_logger_side_effect(name: str | None = None) -> MagicMock:
             if name == "httpx":
                 return mock_httpx_logger
             return mock_root_logger
@@ -54,7 +55,7 @@ def test_configure_logging_custom_level() -> None:
         mock_handler = MagicMock()
 
         # Return different loggers based on name
-        def get_logger_side_effect(name=None):
+        def get_logger_side_effect(name: str | None = None) -> MagicMock:
             if name == "httpx":
                 return mock_httpx_logger
             return mock_root_logger
@@ -86,7 +87,7 @@ def test_configure_logging_invalid_level() -> None:
         mock_handler = MagicMock()
 
         # Return different loggers based on name
-        def get_logger_side_effect(name=None):
+        def get_logger_side_effect(name: str | None = None) -> MagicMock:
             if name == "httpx":
                 return mock_httpx_logger
             return mock_root_logger
@@ -115,7 +116,7 @@ def test_configure_logging_removes_existing_handlers() -> None:
         mock_existing_handler = MagicMock()
         mock_handler = MagicMock()
 
-        def get_logger_side_effect(name=None):
+        def get_logger_side_effect(name: str | None = None) -> MagicMock:
             if name == "httpx":
                 return mock_httpx_logger
             return mock_root_logger
@@ -145,7 +146,7 @@ def test_configure_logging_uses_custom_formatter() -> None:
         mock_handler = MagicMock()
         mock_formatter = MagicMock()
 
-        def get_logger_side_effect(name=None):
+        def get_logger_side_effect(name: str | None = None) -> MagicMock:
             if name == "httpx":
                 return mock_httpx_logger
             return mock_root_logger
@@ -173,7 +174,7 @@ def test_configure_logging_httpx_warning() -> None:
         mock_httpx_logger = MagicMock()
         mock_handler = MagicMock()
 
-        def get_logger_side_effect(name=None):
+        def get_logger_side_effect(name: str | None = None) -> MagicMock:
             if name == "httpx":
                 return mock_httpx_logger
             return mock_root_logger

--- a/tests/transform/test_summarization.py
+++ b/tests/transform/test_summarization.py
@@ -212,7 +212,7 @@ async def test_summarize_uncached() -> None:
         assert result == "New summary"
         mock_provider.get.assert_called_once()
         mock_provider.put.assert_called_once_with(
-            "summary:75b697462588792e2fc85fa00b5dc51992b25be2d780349f0827fea9311aea8b:en",
+            "summary::75b697462588792e2fc85fa00b5dc51992b25be2d780349f0827fea9311aea8b:en",
             "New summary",
             mock_settings.cache_summary_ttl_seconds,
         )

--- a/tests/transform/test_summarization.py
+++ b/tests/transform/test_summarization.py
@@ -1,6 +1,7 @@
-from unittest.mock import patch, MagicMock
-from src.transform.summarization import OpenAISummarizer
+from unittest.mock import MagicMock, patch
+
 from src.config import Settings
+from src.transform.summarization import OpenAISummarizer
 
 
 def build_settings(**overrides: object) -> Settings:

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -3,14 +3,13 @@ Tests for cache compression utilities.
 """
 
 import pytest
-
 from src.utils.compression import (
-    CompressionMethod,
+    COMPRESSION_PREFIXES,
     CompressionError,
+    CompressionMethod,
     compress,
     decompress,
     get_compression_stats,
-    COMPRESSION_PREFIXES,
 )
 
 
@@ -80,7 +79,7 @@ class TestCompressionMethods:
 
     def test_unicode_text(self):
         """Test compression of Unicode text."""
-        original_data = "Привет мир! Hello world! 你好世界!".encode("utf-8")
+        original_data = "Привет мир! Hello world! 你好世界!".encode()
         compressed = compress(original_data, CompressionMethod.GZIP)
         decompressed = decompress(compressed)
         assert decompressed == original_data

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -25,7 +25,7 @@ class TestCompressionMethods:
             CompressionMethod.LZMA,
         ],
     )
-    def test_compress_decompress_roundtrip(self, method):
+    def test_compress_decompress_roundtrip(self, method: CompressionMethod) -> None:
         """Test that data can be compressed and decompressed back to original."""
         original_data = b"Hello, World! This is a test string for compression."
         compressed = compress(original_data, method)
@@ -40,7 +40,7 @@ class TestCompressionMethods:
             CompressionMethod.LZMA,
         ],
     )
-    def test_compression_savings(self, method):
+    def test_compression_savings(self, method: CompressionMethod) -> None:
         """Test that compression actually reduces data size for reasonable input."""
         # Create repetitive text that compresses well
         original_data = b"A" * 1000 + b"B" * 1000 + b"C" * 1000
@@ -48,20 +48,20 @@ class TestCompressionMethods:
         # Should compress to less than original (including prefix byte)
         assert len(compressed) < len(original_data)
 
-    def test_none_compression_no_savings(self):
+    def test_none_compression_no_savings(self) -> None:
         """Test that NONE method adds only prefix byte."""
         original_data = b"Test data"
         compressed = compress(original_data, CompressionMethod.NONE)
         assert len(compressed) == len(original_data) + 1  # +1 for prefix
 
-    def test_empty_data(self):
+    def test_empty_data(self) -> None:
         """Test compression of empty data."""
         original_data = b""
         compressed = compress(original_data, CompressionMethod.GZIP)
         decompressed = decompress(compressed)
         assert decompressed == original_data
 
-    def test_large_data(self):
+    def test_large_data(self) -> None:
         """Test compression of larger data."""
         original_data = b"Hello World! " * 10000
         compressed = compress(original_data, CompressionMethod.GZIP)
@@ -70,14 +70,14 @@ class TestCompressionMethods:
         # Should achieve significant compression
         assert len(compressed) < len(original_data) * 0.1  # At least 90% compression
 
-    def test_binary_data(self):
+    def test_binary_data(self) -> None:
         """Test compression of binary data."""
         original_data = bytes(range(256)) * 100
         compressed = compress(original_data, CompressionMethod.GZIP)
         decompressed = decompress(compressed)
         assert decompressed == original_data
 
-    def test_unicode_text(self):
+    def test_unicode_text(self) -> None:
         """Test compression of Unicode text."""
         original_data = "Привет мир! Hello world! 你好世界!".encode()
         compressed = compress(original_data, CompressionMethod.GZIP)
@@ -88,12 +88,12 @@ class TestCompressionMethods:
 class TestCompressionPrefixes:
     """Test compression method prefixes."""
 
-    def test_all_methods_have_unique_prefixes(self):
+    def test_all_methods_have_unique_prefixes(self) -> None:
         """Test that each compression method has a unique prefix."""
         prefixes = list(COMPRESSION_PREFIXES.values())
         assert len(prefixes) == len(set(prefixes)), "Duplicate prefixes found"
 
-    def test_prefix_is_first_byte(self):
+    def test_prefix_is_first_byte(self) -> None:
         """Test that prefix is stored as first byte."""
         for method, expected_prefix in COMPRESSION_PREFIXES.items():
             compressed = compress(b"test data", method)
@@ -103,16 +103,16 @@ class TestCompressionPrefixes:
 class TestDecompressionErrors:
     """Test decompression error handling."""
 
-    def test_unknown_prefix_raises_error(self):
+    def test_unknown_prefix_raises_error(self) -> None:
         """Test that unknown prefix raises CompressionError."""
         with pytest.raises(CompressionError, match="Unknown compression prefix"):
             decompress(b"\xffinvalid data")
 
-    def test_empty_data_returns_empty(self):
+    def test_empty_data_returns_empty(self) -> None:
         """Test that empty data returns empty."""
         assert decompress(b"") == b""
 
-    def test_corrupted_data_raises_error(self):
+    def test_corrupted_data_raises_error(self) -> None:
         """Test that corrupted data raises CompressionError."""
         # Create valid compressed data then corrupt it
         original = b"test data"
@@ -126,7 +126,7 @@ class TestDecompressionErrors:
 class TestCompressionStats:
     """Test compression statistics calculation."""
 
-    def test_stats_calculation(self):
+    def test_stats_calculation(self) -> None:
         """Test compression stats are calculated correctly."""
         original = b"A" * 1000
         compressed = compress(original, CompressionMethod.GZIP)
@@ -136,19 +136,20 @@ class TestCompressionStats:
         assert "savings_percent" in stats
         assert "original_size" in stats
         assert "compressed_size" in stats
-        assert stats["original_size"] == 1000
+        expected_original_size = 1000
+        assert stats["original_size"] == expected_original_size
         assert stats["compressed_size"] == len(compressed)
         assert 0 < stats["ratio"] < 1  # Should be compressed
         assert stats["savings_percent"] > 0
 
-    def test_empty_original_data(self):
+    def test_empty_original_data(self) -> None:
         """Test stats with empty original data."""
         stats = get_compression_stats(b"", b"compressed")
         assert stats["ratio"] == 0.0
         assert stats["savings_percent"] == 0.0
         assert stats["original_size"] == 0
 
-    def test_compression_ratio_for_different_methods(self):
+    def test_compression_ratio_for_different_methods(self) -> None:
         """Test that different methods achieve different compression ratios."""
         original = b"Hello World! " * 1000
 
@@ -161,6 +162,7 @@ class TestCompressionStats:
         lzma_stats = get_compression_stats(original, lzma_compressed)
 
         # All should achieve significant compression
-        assert gzip_stats["ratio"] < 0.1
-        assert zlib_stats["ratio"] < 0.1
-        assert lzma_stats["ratio"] < 0.1
+        max_ratio = 0.1
+        assert gzip_stats["ratio"] < max_ratio
+        assert zlib_stats["ratio"] < max_ratio
+        assert lzma_stats["ratio"] < max_ratio

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -39,9 +39,10 @@ def test_to_lexical_chunks_splits_on_sentences() -> None:
 
 def test_to_lexical_chunks_splits_on_words_when_no_sentence_breaks() -> None:
     text = "This is a sentence without sentence breaks but with multiple words"
-    result = to_lexical_chunks(text, 10)
+    expected_max = 10
+    result = to_lexical_chunks(text, expected_max)
     # Should split on word boundaries when no sentence breaks are available
-    assert all(len(chunk) <= 10 or " " not in chunk for chunk in result)
+    assert all(len(chunk) <= expected_max or " " not in chunk for chunk in result)
 
 
 def test_to_lexical_chunks_handles_leading_trailing_whitespace() -> None:


### PR DESCRIPTION
- Extract `UserRateLimiter` to dedicated `src/rate_limiter.py` module
- Add cache provider factory with singleton pattern in `src/cache/factory.py`
- Move transcript caching logic into `VideoDataLoader.load()`
- Move summary caching logic into `OpenAISummarizer.summarize()`
- Convert `VideoDataLoader.load()` and `OpenAISummarizer.summarize_text()` to async
- Expose `normalize_locale()` as public function in localization module
- Simplify bot handler by delegating caching responsibilities to providers
- Move `_parse_compression_method` from `ValkeyProvider` to base `CacheProvider`
- Replace specific `get_summary`/`set_summary` with generic `get`/`put` for text caching
- Replace specific `get_transcript`/`set_transcript` with generic `get_dict`/`put_dict` for dict caching
- Update `LocalCacheProvider` to use unified `_cache` and `_cache_dict` dictionaries
- Update `ValkeyProvider` to inherit compression parsing and use generic cache methods
- Add error handling for decompression failures in Valkey cache operations
- Update `VideoDataLoader` and `OpenAISummarizer` to use new generic cache interface
- Change logging from `info` to `debug` for cache hits
- Simplify ValkeyProvider to log warnings on connection errors without fallback
- Remove LocalCacheProvider dependency and `_local_fallback` instance
- Update `_safe_execute` to return `None` instead of executing fallback coroutine
- Modify all cache operations (`is_rate_limited`, `get`, `put`, `get_dict`, `put_dict`) to return `None`/`False` on Valkey failures
- Update docstrings to reflect fail-soft behavior removal