### PR TITLE
fix(cache): use compression for InMemoryCacheProvider

### DIFF
--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -4,13 +4,13 @@ Cache providers namespace for Go Briefly Bot.
 
 from .base import CacheProvider
 from .factory import get_cache_provider, reset_cache_provider
-from .local import LocalCacheProvider
+from .in_memory import InMemoryCacheProvider
 from .valkey import ValkeyProvider
 
 __all__ = [
     "CacheProvider",
     "get_cache_provider",
     "reset_cache_provider",
-    "LocalCacheProvider",
+    "InMemoryCacheProvider",
     "ValkeyProvider",
 ]

--- a/src/cache/factory.py
+++ b/src/cache/factory.py
@@ -10,7 +10,7 @@ from threading import Lock
 
 from ..config import Settings
 from .base import CacheProvider
-from .local import LocalCacheProvider
+from .in_memory import InMemoryCacheProvider
 from .valkey import ValkeyProvider
 
 _provider_lock = Lock()
@@ -46,7 +46,9 @@ def get_cache_provider(settings: Settings) -> CacheProvider:
                 compression_method=settings.cache_compression_method,
             )
         else:
-            _state.current = LocalCacheProvider()
+            _state.current = InMemoryCacheProvider(
+                compression_method=settings.cache_compression_method,
+            )
 
     if _state.current is None:
         raise RuntimeError("Cache provider not initialized")

--- a/src/cache/in_memory.py
+++ b/src/cache/in_memory.py
@@ -9,19 +9,20 @@ from typing import Any
 from .base import CacheProvider
 
 
-class LocalCacheProvider(CacheProvider):
+class InMemoryCacheProvider(CacheProvider):
     """
     In-memory cache provider using dictionaries.
     Used when Valkey is not configured or unavailable.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, compression_method: str = "gzip") -> None:
+        super().__init__(compression_method)
         self._rate_limits: dict[int, float] = {}
         self._rate_limit_lock = asyncio.Lock()
 
         # Caches
-        self._cache: dict[str, tuple[str, float]] = {}
-        self._cache_dict: dict[str, tuple[dict[str, Any], float]] = {}
+        self._cache: dict[str, tuple[bytes, float]] = {}
+        self._cache_dict: dict[str, tuple[bytes, float]] = {}
         self._cache_lock = asyncio.Lock()
 
     async def is_rate_limited(self, user_id: int, window_seconds: int) -> bool:
@@ -33,38 +34,44 @@ class LocalCacheProvider(CacheProvider):
 
             self._rate_limits[user_id] = now
             return False
+        return False
 
     async def get(self, key: str) -> str | None:
         async with self._cache_lock:
-            cached = self._cache.get(key)
+            cache_key = f"{key}:{self._compression_method.value}"
+            cached = self._cache.get(cache_key)
             if cached is None:
                 return None
 
-            text, expires_at = cached
+            compressed, expires_at = cached
             if time.monotonic() > expires_at:
-                self._cache.pop(key, None)
+                self._cache.pop(cache_key, None)
                 return None
 
-            return text
-        return None
+            return self._decode_text(compressed)
 
     async def put(self, key: str, text: str, ttl_seconds: int) -> None:
         async with self._cache_lock:
-            self._cache[key] = (text, time.monotonic() + ttl_seconds)
+            cache_key = f"{key}:{self._compression_method.value}"
+            compressed = self._encode_text(text)
+            self._cache[cache_key] = (compressed, time.monotonic() + ttl_seconds)
 
     async def get_dict(self, key: str) -> dict[str, Any] | None:
         async with self._cache_lock:
-            cached = self._cache_dict.get(key)
+            cache_key = f"{key}:{self._compression_method.value}"
+            cached = self._cache_dict.get(cache_key)
             if cached is None:
                 return None
 
-            data, expires_at = cached
+            compressed, expires_at = cached
             if time.monotonic() > expires_at:
-                self._cache_dict.pop(key, None)
+                self._cache_dict.pop(cache_key, None)
                 return None
 
-            return data
+            return self._decode_dict(compressed)
 
     async def put_dict(self, key: str, data: dict[str, Any], ttl_seconds: int) -> None:
         async with self._cache_lock:
-            self._cache_dict[key] = (data, time.monotonic() + ttl_seconds)
+            cache_key = f"{key}:{self._compression_method.value}"
+            compressed = self._encode_dict(data)
+            self._cache_dict[cache_key] = (compressed, time.monotonic() + ttl_seconds)

--- a/tests/cache/test_in_memory.py
+++ b/tests/cache/test_in_memory.py
@@ -1,16 +1,16 @@
 import asyncio
 
 import pytest
-from src.cache import LocalCacheProvider
+from src.cache import InMemoryCacheProvider
 
 
 @pytest.fixture
-def provider() -> LocalCacheProvider:
-    return LocalCacheProvider()
+def provider() -> InMemoryCacheProvider:
+    return InMemoryCacheProvider()
 
 
 @pytest.mark.asyncio
-async def test_local_rate_limit(provider: LocalCacheProvider) -> None:
+async def test_in_memory_rate_limit(provider: InMemoryCacheProvider) -> None:
     # Not limited initially
     is_limited = await provider.is_rate_limited(123, 10)
     assert not is_limited
@@ -21,7 +21,7 @@ async def test_local_rate_limit(provider: LocalCacheProvider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_local_summary_multiple_languages(provider: LocalCacheProvider) -> None:
+async def test_in_memory_summary_multiple_languages(provider: InMemoryCacheProvider) -> None:
     # Set summary in English
     await provider.put("summary:hash123:en", "english summary", 3600)
     # Set summary in Spanish
@@ -41,7 +41,7 @@ async def test_local_summary_multiple_languages(provider: LocalCacheProvider) ->
 
 
 @pytest.mark.asyncio
-async def test_local_summary_expiration(provider: LocalCacheProvider) -> None:
+async def test_in_memory_summary_expiration(provider: InMemoryCacheProvider) -> None:
     # Set with short TTL
     await provider.put("summary:hash123:en", "expiring summary", 1)
 
@@ -56,7 +56,7 @@ async def test_local_summary_expiration(provider: LocalCacheProvider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_local_transcript(provider: LocalCacheProvider) -> None:
+async def test_in_memory_transcript(provider: InMemoryCacheProvider) -> None:
     data = {"text": "hello"}
 
     await provider.put_dict("transcript:hash123", data, 3600)
@@ -66,7 +66,7 @@ async def test_local_transcript(provider: LocalCacheProvider) -> None:
 
 
 @pytest.mark.asyncio
-async def test_local_transcript_expiration(provider: LocalCacheProvider) -> None:
+async def test_in_memory_transcript_expiration(provider: InMemoryCacheProvider) -> None:
     data = {"text": "expiring"}
 
     await provider.put_dict("transcript:hash123", data, 1)

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,13 +1,13 @@
 import asyncio
 
 import pytest
-from src.cache import LocalCacheProvider
+from src.cache import InMemoryCacheProvider
 from src.rate_limiter import UserRateLimiter
 
 
 @pytest.mark.asyncio
 async def test_user_rate_limiter_not_limited() -> None:
-    limiter = UserRateLimiter(provider=LocalCacheProvider(), cooldown_seconds=1)
+    limiter = UserRateLimiter(provider=InMemoryCacheProvider(), cooldown_seconds=1)
 
     # First request should not be limited
     is_limited = await limiter.is_limited(123)
@@ -20,7 +20,7 @@ async def test_user_rate_limiter_not_limited() -> None:
 
 @pytest.mark.asyncio
 async def test_user_rate_limiter_different_users() -> None:
-    limiter = UserRateLimiter(provider=LocalCacheProvider(), cooldown_seconds=1)
+    limiter = UserRateLimiter(provider=InMemoryCacheProvider(), cooldown_seconds=1)
 
     # Different users should not affect each other
     is_limited_user1 = await limiter.is_limited(123)
@@ -32,7 +32,7 @@ async def test_user_rate_limiter_different_users() -> None:
 
 @pytest.mark.asyncio
 async def test_user_rate_limiter_after_cooldown() -> None:
-    limiter = UserRateLimiter(provider=LocalCacheProvider(), cooldown_seconds=1)  # Short cooldown for testing
+    limiter = UserRateLimiter(provider=InMemoryCacheProvider(), cooldown_seconds=1)  # Short cooldown for testing
 
     # First request
     is_limited = await limiter.is_limited(123)


### PR DESCRIPTION
- Rename `LocalCacheProvider` to `InMemoryCacheProvider` for clarity
- Add compression support to in-memory cache provider using base class methods
- Move compression encoding/decoding logic to `CacheProvider` base class
- Update `ValkeyProvider` to use inherited compression methods
- Include compression method in cache keys for compatibility
- Update factory to initialize provider with settings-based compression
- Rename and update all related tests

BREAKING CHANGE: `LocalCacheProvider` has been renamed to `InMemoryCacheProvider`. Update imports and instantiations accordingly. The constructor now accepts an optional `compression_method` parameter (defaults to "gzip").