### PR TITLE
feat(telegram): add thumbnail support for video summaries

### DIFF
--- a/src/client/telegram/handlers/messages.py
+++ b/src/client/telegram/handlers/messages.py
@@ -172,8 +172,15 @@ async def handle_message(  # noqa: C901, PLR0911
         title=transcript.title,
         url=video_url,
     )
-    response = f"{title}\n{summary}".strip()
-    chunks = to_lexical_chunks(response, settings.max_telegram_message_length)
+
+    anchor = message
+    if transcript.thumbnail:
+        anchor = await message.reply_photo(
+            photo=transcript.thumbnail,
+            caption=markdown_to_telegram_html(title),
+        )
+
+    chunks = to_lexical_chunks(summary.strip(), settings.max_telegram_message_length)
     for i, chunk in enumerate(chunks):
         logger.debug(
             "Sending response chunk",
@@ -184,9 +191,9 @@ async def handle_message(  # noqa: C901, PLR0911
                 "chunk_index": i,
             },
         )
-        await message.reply(
+        await anchor.reply(
             text=markdown_to_telegram_html(chunk),
-            link_preview_options=LinkPreviewOptions(is_disabled=False, url=video_url, show_above_text=True),
+            link_preview_options=LinkPreviewOptions(is_disabled=True),
         )
 
     logger.info(


### PR DESCRIPTION
- Send video thumbnail as photo when available instead of text-only response
- Use thumbnail photo caption for the video title
- Send summary content as separate message chunks
- Disable link preview options for all message chunks