### PR TITLE
fix(docker): correct entrypoint module path

### DIFF
--- a/.devops/Telegram.Dockerfile
+++ b/.devops/Telegram.Dockerfile
@@ -27,4 +27,4 @@ RUN addgroup -g $UID appgroup && \
     chown -R appuser:appgroup /app
 USER appuser
 
-ENTRYPOINT ["python", "-m", "src.main"]
+ENTRYPOINT ["python", "-m", "src.client.telegram.main"]


### PR DESCRIPTION
- Update Dockerfile entrypoint from `src.main` to `src.client.telegram.main`