### PR TITLE
feat(telegram): add proxy support for Telegram Bot API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Telegram
 TELEGRAM_BOT_TOKEN=
+# Proxy (optional). If auth is used, set both username and password.
+TELEGRAM_PROXY_URL=protocol://user:password@host:port
 
 # Telegram message chunking
 MAX_TELEGRAM_MESSAGE_LENGTH=3500

--- a/README.md
+++ b/README.md
@@ -148,15 +148,19 @@ Press `F5` to start debugging. Available configurations:
 | Variable                       | Description                        | Default                          |
 | ------------------------------ | ---------------------------------- | -------------------------------- |
 | `TELEGRAM_BOT_TOKEN`           | Telegram bot token (required)      | —                                |
+| `TELEGRAM_PROXY_URL`           | Proxy URL for Telegram API         | —                                |
 | `OPENAI_API_KEY`               | LLM API key (required)             | —                                |
 | `OPENAI_MODEL`                 | Model for summarization (required) | —                                |
 | `OPENAI_BASE_URL`              | OpenAI-compatible API base URL     | `https://api.openai.com/v1/`     |
+| `OPENAI_TIMEOUT_SECONDS`       | LLM request timeout                | `300`                            |
+| `OPENAI_MAX_RETRIES`           | LLM max retry attempts             | `3`                              |
 | `YT_DLP_ADDITIONAL_OPTIONS`    | Additional yt-dlp options          | —                                |
 | `VALKEY_URL`                   | Valkey connection URL (optional)   | —                                |
 | `CACHE_SUMMARY_TTL_SECONDS`    | TTL for cached summaries           | `3600` (local), `86400` (Valkey) |
 | `CACHE_TRANSCRIPT_TTL_SECONDS` | TTL for cached transcripts         | `3600` (local), `86400` (Valkey) |
 | `CACHE_COMPRESSION_METHOD`     | Compression for Valkey cache       | `gzip` (none, gzip, zlib, lzma)  |
 | `MAX_TELEGRAM_MESSAGE_LENGTH`  | Max length for Telegram messages   | `3500`                           |
+| `RATE_LIMIT_WINDOW_SECONDS`    | Cooldown between user requests     | `10`                             |
 | `LOG_LEVEL`                    | Logging level                      | `INFO`                           |
 
 ## Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 
 dependencies = [
     "aiogram>=3.4.0,<4.0.0",
+    "aiohttp-socks>=0.11.0,<1.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "python-i18n[YAML]>=0.3.9",
     "openai>=1.0.0,<2.0.0",

--- a/src/client/telegram/main.py
+++ b/src/client/telegram/main.py
@@ -5,6 +5,7 @@ import logging
 
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
+from aiogram.client.session.aiohttp import AiohttpSession
 from aiogram.enums import ParseMode
 
 from src.cache.base import CacheProvider
@@ -35,8 +36,13 @@ async def main() -> None:
     dp = Dispatcher()
     dp.include_routers(commands_router, messages_router, errors_router)
 
+    session: AiohttpSession | None = None
+    if settings.telegram_proxy_url:
+        session = AiohttpSession(proxy=settings.telegram_proxy_url)
+
     bot = Bot(
         token=settings.telegram_bot_token,
+        session=session,
         default=DefaultBotProperties(parse_mode=ParseMode.HTML),
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -10,8 +10,19 @@ from __future__ import annotations
 import os
 import shlex
 from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
+
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1/"
+DEFAULT_OPENAI_TIMEOUT_SECONDS = 300
+DEFAULT_OPENAI_MAX_RETRIES = 3
+DEFAULT_CACHE_TTL_WITH_VALKEY = 86400
+DEFAULT_CACHE_TTL_NO_VALKEY = 3600
+DEFAULT_CACHE_COMPRESSION_METHOD = "gzip"
+DEFAULT_RATE_LIMIT_WINDOW_SECONDS = 10
+DEFAULT_MAX_TELEGRAM_MESSAGE_LENGTH = 3500
 
 
 @dataclass(frozen=True)
@@ -21,36 +32,22 @@ class Settings:
 
     Immutable configuration class (frozen dataclass) that ensures
     settings cannot be modified after initialization.
-
-    Attributes:
-        telegram_bot_token: Telegram Bot API token.
-        openai_base_url: Base URL for OpenAI-compatible API.
-        openai_api_key: API key for LLM service.
-        openai_model: Model name to use for summarization.
-        valkey_url: Optional connection string for Valkey (replaces in-memory state).
-        yt_dlp_additional_options: Additional yt-dlp CLI options.
-        rate_limit_window_seconds: Cooldown between user requests.
-        cache_summary_ttl_seconds: TTL for cached video summaries (in seconds). Defaults to 1 hour for local cache, 1 day for Valkey.
-        cache_transcript_ttl_seconds: TTL for cached video transcripts (in seconds). Defaults to 1 hour for local cache, 1 day for Valkey.
-        cache_compression_method: Compression method for Valkey cache (none, gzip, zlib, lzma).
-        max_telegram_message_length: Maximum message length before chunking.
-        openai_timeout_seconds: Timeout for LLM API requests.
-        openai_max_retries: Maximum retry attempts for LLM API.
     """
 
     telegram_bot_token: str
+    telegram_proxy_url: str | None
     openai_base_url: str
     openai_api_key: str
     openai_model: str
     yt_dlp_additional_options: tuple[str, ...]
     valkey_url: str | None = None
-    cache_summary_ttl_seconds: int = 86400
-    cache_transcript_ttl_seconds: int = 86400
-    cache_compression_method: str = "gzip"
-    rate_limit_window_seconds: int = 10
-    max_telegram_message_length: int = 3500
-    openai_timeout_seconds: int = 300
-    openai_max_retries: int = 3
+    cache_summary_ttl_seconds: int = DEFAULT_CACHE_TTL_WITH_VALKEY
+    cache_transcript_ttl_seconds: int = DEFAULT_CACHE_TTL_WITH_VALKEY
+    cache_compression_method: str = DEFAULT_CACHE_COMPRESSION_METHOD
+    rate_limit_window_seconds: int = DEFAULT_RATE_LIMIT_WINDOW_SECONDS
+    max_telegram_message_length: int = DEFAULT_MAX_TELEGRAM_MESSAGE_LENGTH
+    openai_timeout_seconds: int = DEFAULT_OPENAI_TIMEOUT_SECONDS
+    openai_max_retries: int = DEFAULT_OPENAI_MAX_RETRIES
 
     @classmethod
     def from_env(cls) -> Settings:
@@ -65,67 +62,72 @@ class Settings:
         Raises:
             RuntimeError: If required environment variables are missing.
         """
-
         load_dotenv()
+        env_vars = _load_env_vars()
+        _validate_env_vars(env_vars)
+        return cls(**env_vars)
 
-        telegram_bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
-        openai_base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1/").strip()
-        openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
-        openai_model = os.getenv("OPENAI_MODEL", "").strip()
-        valkey_url = os.getenv("VALKEY_URL", "").strip() or None
 
-        # Default TTL values depend on cache type: 1 hour for local, 1 day for Valkey
-        default_summary_ttl = 3600 if valkey_url is None else 86400
-        default_transcript_ttl = 3600 if valkey_url is None else 86400
+def _load_env_vars() -> dict[str, Any]:
+    """Load and parse all environment variables into a dictionary."""
+    telegram_bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    telegram_proxy_url = os.getenv("TELEGRAM_PROXY_URL", "").strip() or None
+    openai_base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL).strip()
+    openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    openai_model = os.getenv("OPENAI_MODEL", "").strip()
+    valkey_url = os.getenv("VALKEY_URL", "").strip() or None
 
-        try:
-            cache_summary_ttl = int(os.getenv("CACHE_SUMMARY_TTL_SECONDS", str(default_summary_ttl)))
-        except ValueError:
-            cache_summary_ttl = default_summary_ttl
+    default_ttl = DEFAULT_CACHE_TTL_NO_VALKEY if valkey_url is None else DEFAULT_CACHE_TTL_WITH_VALKEY
 
-        try:
-            cache_transcript_ttl = int(os.getenv("CACHE_TRANSCRIPT_TTL_SECONDS", str(default_transcript_ttl)))
-        except ValueError:
-            cache_transcript_ttl = default_transcript_ttl
+    return {
+        "telegram_bot_token": telegram_bot_token,
+        "telegram_proxy_url": telegram_proxy_url,
+        "openai_base_url": openai_base_url,
+        "openai_api_key": openai_api_key,
+        "openai_model": openai_model,
+        "openai_timeout_seconds": _load_int("OPENAI_TIMEOUT_SECONDS", DEFAULT_OPENAI_TIMEOUT_SECONDS),
+        "openai_max_retries": _load_int("OPENAI_MAX_RETRIES", DEFAULT_OPENAI_MAX_RETRIES),
+        "valkey_url": valkey_url,
+        "cache_summary_ttl_seconds": _load_int("CACHE_SUMMARY_TTL_SECONDS", default_ttl),
+        "cache_transcript_ttl_seconds": _load_int("CACHE_TRANSCRIPT_TTL_SECONDS", default_ttl),
+        "cache_compression_method": _load_compression_method(),
+        "rate_limit_window_seconds": _load_int("RATE_LIMIT_WINDOW_SECONDS", DEFAULT_RATE_LIMIT_WINDOW_SECONDS),
+        "max_telegram_message_length": _load_int("MAX_TELEGRAM_MESSAGE_LENGTH", DEFAULT_MAX_TELEGRAM_MESSAGE_LENGTH),
+        "yt_dlp_additional_options": tuple(shlex.split(os.getenv("YT_DLP_ADDITIONAL_OPTIONS", ""))),
+    }
 
-        cache_compression = os.getenv("CACHE_COMPRESSION_METHOD", "gzip").strip().lower()
-        valid_compression_methods = {"none", "gzip", "zlib", "lzma"}
-        if cache_compression not in valid_compression_methods:
-            cache_compression = "gzip"
 
-        try:
-            rate_limit_window = int(os.getenv("RATE_LIMIT_WINDOW_SECONDS", "10"))
-        except ValueError:
-            rate_limit_window = 10
+def _load_compression_method() -> str:
+    """Load and validate cache compression method."""
+    cache_compression = os.getenv("CACHE_COMPRESSION_METHOD", DEFAULT_CACHE_COMPRESSION_METHOD).strip().lower()
+    valid_methods = {"none", "gzip", "zlib", "lzma"}
+    return cache_compression if cache_compression in valid_methods else DEFAULT_CACHE_COMPRESSION_METHOD
 
-        yt_dlp_additional_options = tuple(shlex.split(os.getenv("YT_DLP_ADDITIONAL_OPTIONS", "")))
 
-        try:
-            max_telegram_message_length = int(os.getenv("MAX_TELEGRAM_MESSAGE_LENGTH", "3500"))
-        except ValueError:
-            max_telegram_message_length = 3500
+def _load_int(env_var: str, default: int) -> int:
+    """Load integer value from environment with fallback to default."""
+    try:
+        return int(os.getenv(env_var, str(default)))
+    except ValueError:
+        return default
 
-        missing = []
-        if not telegram_bot_token:
-            missing.append("TELEGRAM_BOT_TOKEN")
-        if not openai_api_key:
-            missing.append("OPENAI_API_KEY")
-        if not openai_model:
-            missing.append("OPENAI_MODEL")
 
-        if missing:
-            raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+def _validate_env_vars(env_vars: dict[str, Any]) -> None:
+    """Validate required environment variables and proxy configuration."""
+    missing = []
+    if not env_vars["telegram_bot_token"]:
+        missing.append("TELEGRAM_BOT_TOKEN")
+    if not env_vars["openai_api_key"]:
+        missing.append("OPENAI_API_KEY")
+    if not env_vars["openai_model"]:
+        missing.append("OPENAI_MODEL")
 
-        return cls(
-            telegram_bot_token=telegram_bot_token,
-            openai_base_url=openai_base_url,
-            openai_api_key=openai_api_key,
-            openai_model=openai_model,
-            valkey_url=valkey_url,
-            cache_summary_ttl_seconds=cache_summary_ttl,
-            cache_transcript_ttl_seconds=cache_transcript_ttl,
-            cache_compression_method=cache_compression,
-            rate_limit_window_seconds=rate_limit_window,
-            max_telegram_message_length=max_telegram_message_length,
-            yt_dlp_additional_options=yt_dlp_additional_options,
-        )
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+
+    if env_vars["telegram_proxy_url"]:
+        parsed = urlparse(env_vars["telegram_proxy_url"])
+        if not parsed.scheme or not parsed.hostname or not parsed.port:
+            raise RuntimeError("Invalid TELEGRAM_PROXY_URL format. Expected: protocol://user:password@host:port")
+        if parsed.scheme not in {"http", "https", "socks4", "socks5"}:
+            raise RuntimeError(f"Unsupported proxy protocol: {parsed.scheme}. Supported: http, https, socks4, socks5")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,17 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from src.config import Settings
+from src.config import (
+    DEFAULT_CACHE_COMPRESSION_METHOD,
+    DEFAULT_CACHE_TTL_NO_VALKEY,
+    DEFAULT_CACHE_TTL_WITH_VALKEY,
+    DEFAULT_MAX_TELEGRAM_MESSAGE_LENGTH,
+    DEFAULT_OPENAI_BASE_URL,
+    DEFAULT_OPENAI_MAX_RETRIES,
+    DEFAULT_OPENAI_TIMEOUT_SECONDS,
+    DEFAULT_RATE_LIMIT_WINDOW_SECONDS,
+    Settings,
+)
 
 
 def test_settings_from_env_success() -> None:
@@ -77,12 +87,12 @@ def test_settings_from_env_default_values(mock_load_dotenv: MagicMock) -> None:
     ):
         settings = Settings.from_env()
 
-        expected_rate_limit = 10
-        expected_msg_len = 3500
-        expected_timeout = 300
-        expected_retries = 3
+        expected_rate_limit = DEFAULT_RATE_LIMIT_WINDOW_SECONDS
+        expected_msg_len = DEFAULT_MAX_TELEGRAM_MESSAGE_LENGTH
+        expected_timeout = DEFAULT_OPENAI_TIMEOUT_SECONDS
+        expected_retries = DEFAULT_OPENAI_MAX_RETRIES
         # Check default values
-        assert settings.openai_base_url == "https://api.openai.com/v1/"  # Default from code
+        assert settings.openai_base_url == DEFAULT_OPENAI_BASE_URL
         assert settings.rate_limit_window_seconds == expected_rate_limit
         assert settings.max_telegram_message_length == expected_msg_len
         assert settings.openai_timeout_seconds == expected_timeout
@@ -134,3 +144,154 @@ def test_settings_immutability() -> None:
         # Attempt to modify should raise an exception since it's a frozen dataclass
         with pytest.raises(dataclasses.FrozenInstanceError):
             settings.telegram_bot_token = "new_token"  # type: ignore[misc]
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_invalid_proxy_url(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "TELEGRAM_PROXY_URL": "http://localhost",
+        },
+        clear=True,
+    ):
+        with pytest.raises(RuntimeError, match="Invalid TELEGRAM_PROXY_URL format"):
+            Settings.from_env()
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_valid_proxy_url(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "TELEGRAM_PROXY_URL": "socks5://proxy.example.com:1080",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.telegram_proxy_url == "socks5://proxy.example.com:1080"
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_valid_proxy_url_with_auth(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "TELEGRAM_PROXY_URL": "socks5://user:pass@proxy.example.com:1080",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.telegram_proxy_url == "socks5://user:pass@proxy.example.com:1080"
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_unsupported_proxy_protocol(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "TELEGRAM_PROXY_URL": "ftp://user:pass@proxy.example.com:1080",
+        },
+        clear=True,
+    ):
+        with pytest.raises(RuntimeError, match="Unsupported proxy protocol"):
+            Settings.from_env()
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_compression_method_fallback(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "CACHE_COMPRESSION_METHOD": "invalid",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.cache_compression_method == DEFAULT_CACHE_COMPRESSION_METHOD
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_compression_method_normalized(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "CACHE_COMPRESSION_METHOD": "LZMA",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.cache_compression_method == "lzma"
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_invalid_ints_fall_back(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "OPENAI_TIMEOUT_SECONDS": "not-a-number",
+            "MAX_TELEGRAM_MESSAGE_LENGTH": "nope",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.openai_timeout_seconds == DEFAULT_OPENAI_TIMEOUT_SECONDS
+        assert settings.max_telegram_message_length == DEFAULT_MAX_TELEGRAM_MESSAGE_LENGTH
+
+
+@patch("src.config.load_dotenv")
+def test_settings_from_env_cache_ttl_defaults_depend_on_valkey(mock_load_dotenv: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.cache_summary_ttl_seconds == DEFAULT_CACHE_TTL_NO_VALKEY
+        assert settings.cache_transcript_ttl_seconds == DEFAULT_CACHE_TTL_NO_VALKEY
+
+    with patch.dict(
+        os.environ,
+        {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_MODEL": "gpt-3.5-turbo",
+            "VALKEY_URL": "redis://localhost:6379/0",
+        },
+        clear=True,
+    ):
+        settings = Settings.from_env()
+
+        assert settings.cache_summary_ttl_seconds == DEFAULT_CACHE_TTL_WITH_VALKEY
+        assert settings.cache_transcript_ttl_seconds == DEFAULT_CACHE_TTL_WITH_VALKEY


### PR DESCRIPTION
- Added the `telegram_proxy_url` field to the `Settings` class
- Proxy URL loading and validation is implemented (http, https, socks4, socks5 are supported)
- In `main.py `an `AiohttpSession` is created with a proxy if there is a setting
- Refactoring `config.py `: separate functions for loading and validating environment variables are highlighted